### PR TITLE
feat(wallet): add button/link component

### DIFF
--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "@next/font": "13.1.2",
+    "class-variance-authority": "^0.4.0",
     "next": "13.1.2",
     "react": "18.2.0",
     "react-dom": "18.2.0"

--- a/packages/wallet/src/ui/Button.tsx
+++ b/packages/wallet/src/ui/Button.tsx
@@ -1,0 +1,62 @@
+import { cva, cx, type VariantProps } from 'class-variance-authority'
+import { forwardRef } from 'react'
+
+import { ButtonOrLink, type ButtonOrLinkProps } from './ButtonOrLink'
+
+/**
+ * CVA helps us define variants for our components.
+ *
+ * For this button component, we created two variants: `intent` and `size`.
+ *
+ * The `VariantProps` helper is going to extract the variants types so we can
+ * safely type our button.
+ *
+ * Usage:
+ *  - <Button intent='primary' size='md' className="text-bold">My Button</Button>
+ *
+ * We can define `defaultVariants` for the component. In our case, if there is
+ * no `intent` or `size` passed in, they will use the default variants specified
+ * in `defaultVariants` object (in our case `intent -> primary` and `size => md`).
+ *
+ * Example:
+ *  - <Button>My Button</Button>
+ */
+
+const buttonStyles = cva(['inline-flex items-center justify-center'], {
+  variants: {
+    intent: {
+      primary: ['text-white bg-gradient-to-r from-[#00B1D8] to-[#2EC08C]'],
+      outline: [
+        'bg-transparent text-orange-500 border border-orange-500 hover:text-white hover:bg-orange-500'
+      ]
+    },
+    size: {
+      md: 'px-3 py-2 rounded-md font-medium'
+    }
+  },
+  defaultVariants: {
+    intent: 'primary',
+    size: 'md'
+  }
+})
+
+type ButtonProps = VariantProps<typeof buttonStyles> &
+  ButtonOrLinkProps & {
+    ['aria-label']: string
+  }
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ intent, size, children, className, ...props }, ref) => {
+    return (
+      <ButtonOrLink
+        ref={ref}
+        className={cx(className, buttonStyles({ intent, size }))}
+        {...props}
+      >
+        {children}
+      </ButtonOrLink>
+    )
+  }
+)
+
+Button.displayName = 'Button'

--- a/packages/wallet/src/ui/Button.tsx
+++ b/packages/wallet/src/ui/Button.tsx
@@ -12,7 +12,7 @@ import { ButtonOrLink, type ButtonOrLinkProps } from './ButtonOrLink'
  * safely type our button.
  *
  * Usage:
- *  - <Button intent='primary' size='md' className="text-bold">My Button</Button>
+ *  - <Button intent='primary' size='md'>My Button</Button>
  *
  * We can define `defaultVariants` for the component. In our case, if there is
  * no `intent` or `size` passed in, they will use the default variants specified

--- a/packages/wallet/src/ui/ButtonOrLink.tsx
+++ b/packages/wallet/src/ui/ButtonOrLink.tsx
@@ -1,0 +1,24 @@
+import { forwardRef } from 'react'
+import type { ComponentProps } from 'react'
+import Link from 'next/link'
+
+export type ButtonOrLinkProps = Omit<
+  ComponentProps<'button'> & ComponentProps<'a'>,
+  'ref'
+>
+
+export const ButtonOrLink = forwardRef<
+  HTMLButtonElement | HTMLAnchorElement,
+  ButtonOrLinkProps
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+>(({ href, ...props }, ref: any) => {
+  const isLink = typeof href !== 'undefined'
+
+  if (isLink) {
+    return <Link href={href} ref={ref} {...props} />
+  }
+
+  return <button {...props} type={props.type ?? 'button'} ref={ref} />
+})
+
+ButtonOrLink.displayName = 'ButtonOrLink'

--- a/packages/wallet/src/ui/Link.tsx
+++ b/packages/wallet/src/ui/Link.tsx
@@ -1,0 +1,11 @@
+import { forwardRef } from 'react'
+
+import { ButtonOrLink, type ButtonOrLinkProps } from './ButtonOrLink'
+
+type LinkProps = ButtonOrLinkProps
+
+export const Link = forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => {
+  return <ButtonOrLink className="underline" {...props} ref={ref} />
+})
+
+Link.displayName = 'Link'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,7 @@ importers:
       '@types/react': 18.0.26
       '@types/react-dom': 18.0.10
       autoprefixer: ^10.4.13
+      class-variance-authority: ^0.4.0
       next: 13.1.2
       postcss: ^8.4.21
       react: 18.2.0
@@ -58,6 +59,7 @@ importers:
       typescript: ^4.9.4
     dependencies:
       '@next/font': 13.1.2
+      class-variance-authority: 0.4.0_typescript@4.9.4
       next: 13.1.2_biqbaboplfbrettd7655fr4n2y
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -1013,6 +1015,17 @@ packages:
     optionalDependencies:
       fsevents: 2.3.2
     dev: true
+
+  /class-variance-authority/0.4.0_typescript@4.9.4:
+    resolution: {integrity: sha512-74enNN8O9ZNieycac/y8FxqgyzZhZbxmCitAtAeUrLPlxjSd5zA7LfpprmxEcOmQBnaGs5hYhiSGnJ0mqrtBLQ==}
+    peerDependencies:
+      typescript: '>= 4.5.5 < 5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      typescript: 4.9.4
+    dev: false
 
   /client-only/0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
@@ -3432,7 +3445,6 @@ packages:
     resolution: {integrity: sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==}
     engines: {node: '>=4.2.0'}
     hasBin: true
-    dev: true
 
   /unbox-primitive/1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}


### PR DESCRIPTION
- `ButtonOrLink` helper component
- `Button` and `Link` component that are using `ButtonOrLink`

`ButtonOrLink` component renders a `button` or an `a`, based on the props that are passed to it.