### PR TITLE
fix: cookie issues for login and refresh

### DIFF
--- a/packages/backend/src/auth/models/refreshToken.ts
+++ b/packages/backend/src/auth/models/refreshToken.ts
@@ -15,8 +15,12 @@ export class RefreshToken extends Model {
   constructor(token = '', userId = '', expiresIn = 0) {
     super()
     this.token = token
-    this.expiresAt = new Date(Date.now() + expiresIn ?? 0 * 1000)
+    this.expiresAt = RefreshToken.expiresInToExpiresAt(expiresIn)
     this.userId = userId
+  }
+
+  static expiresInToExpiresAt(expiresIn: number): Date {
+    return new Date(Date.now() + expiresIn ?? 0 * 1000)
   }
 
   static async verify(token: string): Promise<RefreshToken> {


### PR DESCRIPTION

fixes #140 

### Context

the bug was related to using objection .patch() without providing the id of the patched item.


### Changes
Extracted the expiresInToExpiresAt into a static method of the RefreshToken class. It is now used in the constructor and in the auth service as well. This way, new Tokens are no longer instantiated when having to update older ones.