### PR TITLE
bug(wallet): fix issue with Safari and svg element

### DIFF
--- a/packages/wallet/src/components/PaymentPointerCard.tsx
+++ b/packages/wallet/src/components/PaymentPointerCard.tsx
@@ -157,7 +157,7 @@ export const PaymentPointerCard = ({
 }
 
 const cardStyles = `
-flex items-center justify-between border-b border-b-green-4 px-2 py-3
+flex items-center justify-between border-b border-b-green-4 px-2 pb-3 pt-1
 [&:nth-child(4n+1)_div_button]:bg-green-5 [&:nth-child(4n+1)_div_button:hover]:bg-green-6 
 [&:nth-child(4n+2)_div_button]:bg-violet-1 [&:nth-child(4n+2)_div_button:hover]:bg-violet-2
 [&:nth-child(4n+3)_div_button]:bg-pink-1 [&:nth-child(4n+3)_div_button:hover]:bg-pink-2

--- a/packages/wallet/src/components/icons/Pencil.tsx
+++ b/packages/wallet/src/components/icons/Pencil.tsx
@@ -6,6 +6,8 @@ export const PencilSquare = (props: SVGProps<SVGSVGElement>) => {
       xmlns="http://www.w3.org/2000/svg"
       fill="none"
       viewBox="0 0 24 24"
+      width={24}
+      height={24}
       strokeWidth={1.5}
       stroke="currentColor"
       {...props}

--- a/packages/wallet/src/components/icons/X.tsx
+++ b/packages/wallet/src/components/icons/X.tsx
@@ -6,6 +6,8 @@ export const X = (props: SVGProps<SVGSVGElement>) => {
       xmlns="http://www.w3.org/2000/svg"
       fill="none"
       viewBox="0 0 24 24"
+      width={24}
+      height={24}
       stroke="url(#x-blue-green)"
       strokeWidth={1.5}
       {...props}


### PR DESCRIPTION
<!--
If the PR is related to an open issue(s) please provide a list of them.

Example:
    - closes (or fixes) #<issue number>
    - closes (or fixes) #<issue number>
-->
### Context
- fixes #146 

<!--
Short description of what has changed
-->
### Changes
Added width and height to svg elements for them to be displayed correctly in Safari as well
Arranged the Payment pointer cards to be the same distance from top to bottom