### PR TITLE
feat(noKyc): Add me endpoint to be used as authenticated middleware by next

### DIFF
--- a/packages/backend/src/routes.ts
+++ b/packages/backend/src/routes.ts
@@ -1,12 +1,13 @@
 import express, { Request, Response } from 'express'
 import passport from 'passport'
-import { login, refresh, signup } from './auth/auth.service'
+import { login, me, refresh, signup } from './auth/auth.service'
 
 export const mainRouter = express.Router()
 
 mainRouter.post('/signup', signup)
 mainRouter.post('/login', login)
 mainRouter.post('/refresh', refresh)
+mainRouter.get('/me', me)
 
 mainRouter.post(
   '/protected',

--- a/packages/backend/src/shared/models/errors/NotFoundException.ts
+++ b/packages/backend/src/shared/models/errors/NotFoundException.ts
@@ -1,0 +1,7 @@
+import { BaseError } from './BaseError'
+export class NotFoundException extends BaseError {
+  constructor() {
+    super(404, 'Not found')
+    Object.setPrototypeOf(this, NotFoundException.prototype)
+  }
+}


### PR DESCRIPTION
Issued for #161 (just the backend support)


### Context
NextJS needs a middleware to decide if the user is authenticated or not before rendering pages. 
As such, a /me endpoint that acts as a user profile GET would be benefic

### Changes

Introduced the /me endpoint, that returns the no-kyc information and acts as an "is authenticated" middelware for nextjs