### PR TITLE
fixes(refreshTokens): Fix refresh token not being set on 1st login of user

### DIFF
--- a/packages/backend/src/auth/auth.service.ts
+++ b/packages/backend/src/auth/auth.service.ts
@@ -120,14 +120,14 @@ export const login = async (
       refreshToken.expiresAt = RefreshToken.expiresInToExpiresAt(
         refreshTokenExpiresIn
       )
-      await refreshToken.$query().patch(refreshToken)
+      await refreshToken.$query().patch({ ...refreshToken })
     } else {
       refreshToken = new RefreshToken(
         generatedToken,
         user.id,
         refreshTokenExpiresIn
       )
-      await user.$relatedQuery('refreshTokens').insert(refreshToken)
+      await user.$relatedQuery('refreshTokens').insert({ ...refreshToken })
     }
 
     const { accessToken, expiresIn: accessTokenExpiresIn } = generateJWT(user)


### PR DESCRIPTION
This PR fixes refresh tokens returned on cookies

### Context
When users had no refresh tokens yet (at their first login), the refresh token was not returned on the response cookies.
### Changes

Added the spread operator, so that new object references are passed.
It seems that objection actually instantiates the objects passed, and they called new on the passed refreshToken.
This resulted in a constructor call with no parameters, defaulting to empty strings for the token value and userId + the value 0 for expired at.
Will further look into the inner workings of objection, since this behaviour is kind of weird, doing an unexpected mutation.
But for now, the fix was just adding spread operators in order to pass new objects as parameters