### PR TITLE
fix: add missing env variable for legacy compose

### DIFF
--- a/docker/dev/docker-compose-legacy.yml
+++ b/docker/dev/docker-compose-legacy.yml
@@ -35,6 +35,7 @@ services:
       JWT_REFRESH_TOKEN_EXPIRATION_TIME: 2630000
       RAPYD_API: https://sandboxapi.rapyd.net/v1
       RAPYD_ACCESS_KEY: ${RAPYD_ACCESS_KEY}
+      RAPYD_SETTLEMENT_EWALLET: ${RAPYD_SETTLEMENT_EWALLET}
       RAPYD_SECRET_KEY: ${RAPYD_SECRET_KEY}
       OPEN_PAYMENTS_HOST: https://rafiki-backend
       GRAPHQL_ENDPOINT: http://rafiki-backend:3001/graphql


### PR DESCRIPTION
<!--
If the PR is related to an open issue(s) please provide a list of them.

Example:
    - closes (or fixes) #<issue number>
    - closes (or fixes) #<issue number>
-->
### Context
- When merging the new backend scaffold, we moved the current backend into the `docker-compose-legacy.yml`. I forgot to add the new environment variable `RAPYD_SETTLEMENT_EWALLET` to it.

<!--
Short description of what has changed
-->
### Changes