### PR TITLE
chore: update pnpm version for signatures app in docker file

### DIFF
--- a/docker/dev/local-http-signatures/Dockerfile
+++ b/docker/dev/local-http-signatures/Dockerfile
@@ -7,7 +7,7 @@ RUN apt install -y curl xz-utils python3 build-essential
 
 # version in curl is not the version used. Dependent on the last command
 RUN corepack enable
-RUN corepack prepare pnpm@7.25.1 --activate
+RUN corepack prepare pnpm@8.6.0 --activate
 
 # pnpm fetch does require only lockfile
 COPY pnpm-lock.yaml ./


### PR DESCRIPTION
<!--
If the PR is related to an open issue(s) please provide a list of them.

Example:
    - closes (or fixes) #<issue number>
    - closes (or fixes) #<issue number>
-->
### Context
```
 => CACHED [ 2/10] WORKDIR /workspace                                                                                                      0.0s
 => CACHED [ 3/10] RUN apt update                                                                                                          0.0s
 => CACHED [ 4/10] RUN apt install -y curl xz-utils python3 build-essential                                                                0.0s
 => CACHED [ 5/10] RUN corepack enable                                                                                                     0.0s
 => CACHED [ 6/10] RUN corepack prepare pnpm@7.25.1 --activate                                                                             0.0s
 => CACHED [ 7/10] COPY pnpm-lock.yaml ./                                                                                                  0.0s
 => ERROR [ 8/10] RUN pnpm fetch                                                                                                           1.0s
------
 > [ 8/10] RUN pnpm fetch:
#0 0.914  WARN  Your pnpm-lock.yaml was generated by a newer version of pnpm. It is a compatible version but it might get downgraded to version 6.0
#0 0.916 Importing packages to virtual store
#0 0.942 Already up to date
#0 0.945  WARN  Broken lockfile: no entry for '/@typescript-eslint/eslint-plugin/5.59.7(@typescript-eslint/parser@5.59.7)(eslint@8.41.0)(typescript@5.0.4)' in pnpm-lock.yaml
[+] Building 2.1s (11/14)
```
<!--
Short description of what has changed
-->
### Changes