### PR TITLE
feat: set rate limit on signup

### DIFF
--- a/packages/wallet/backend/package.json
+++ b/packages/wallet/backend/package.json
@@ -14,6 +14,7 @@
     "date-fns": "^2.30.0",
     "disposable-email-domains": "^1.0.62",
     "express": "^4.18.2",
+    "express-rate-limit": "^6.8.1",
     "graphql": "^16.7.1",
     "graphql-request": "^6.1.0",
     "hash-wasm": "^4.9.0",

--- a/packages/wallet/backend/src/app.ts
+++ b/packages/wallet/backend/src/app.ts
@@ -37,6 +37,7 @@ import { QuoteService } from './quote/service'
 import { RafikiAuthService } from '@/rafiki/auth/service'
 import { GrantController } from '@/grant/controller'
 import { EmailService } from '@/email/service'
+import { setRateLimit } from '@/middleware/rateLimit'
 
 export interface Bindings {
   env: Env
@@ -147,7 +148,7 @@ export class App {
     app.use(withSession)
 
     // Auth Routes
-    router.post('/signup', authController.signUp)
+    router.post('/signup', setRateLimit(2, 5 * 60, true), authController.signUp)
     router.post('/login', authController.logIn)
     router.post('/logout', isAuth, authController.logOut)
 

--- a/packages/wallet/backend/src/middleware/rateLimit.ts
+++ b/packages/wallet/backend/src/middleware/rateLimit.ts
@@ -1,0 +1,27 @@
+import { env } from '@/config/env'
+import rateLimit from 'express-rate-limit'
+import { NextFunction, Request, Response } from 'express'
+
+export const setRateLimit = (
+  requests: number,
+  intervalSeconds: number,
+  skipFailedRequests: boolean = false
+) => {
+  if (env.NODE_ENV !== 'production') {
+    return (_req: Request, _res: Response, next: NextFunction) => {
+      next()
+    }
+  }
+
+  return rateLimit({
+    windowMs: intervalSeconds * 1000,
+    max: requests,
+    skipFailedRequests,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: {
+      message: 'Too many requests, please try again later.',
+      success: false
+    }
+  })
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       express:
         specifier: ^4.18.2
         version: 4.18.2
+      express-rate-limit:
+        specifier: ^6.8.1
+        version: 6.8.1(express@4.18.2)
       graphql:
         specifier: ^16.7.1
         version: 16.7.1
@@ -4281,6 +4284,15 @@ packages:
       jest-message-util: 29.6.2
       jest-util: 29.6.2
     dev: true
+
+  /express-rate-limit@6.8.1(express@4.18.2):
+    resolution: {integrity: sha512-xJyudsE60CsDShK74Ni1MxsldYaIoivmG3ieK2tAckMsYCBewEuGalss6p/jHmFFnqM9xd5ojE0W2VlanxcOKg==}
+    engines: {node: '>= 14.0.0'}
+    peerDependencies:
+      express: ^4 || ^5
+    dependencies:
+      express: 4.18.2
+    dev: false
 
   /express@4.18.2:
     resolution: {integrity: sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==}


### PR DESCRIPTION
<!--
If the PR is related to an open issue(s) please provide a list of them.

Example:
    - closes (or fixes) #<issue number>
    - closes (or fixes) #<issue number>
-->

### Context

- fixes #537

<!--
Short description of what has changed
-->

### Changes
- limit successful signup requests to 2 per 5 minutes on production (disabled on dev)
