### PR TITLE
feat(backend): Slow incoming payments

### DIFF
--- a/packages/wallet/backend/src/quote/service.ts
+++ b/packages/wallet/backend/src/quote/service.ts
@@ -118,7 +118,7 @@ export class QuoteService implements IQuoteService {
         },
         paymentPointerUrl: params.receiver,
         description: params.description,
-        expiresAt: new Date(Date.now() + 1000 * 60 * 2)
+        expiresAt: new Date(Date.now() + 1000 * 15)
       })
     }
 

--- a/packages/wallet/backend/src/rafiki/controller.ts
+++ b/packages/wallet/backend/src/rafiki/controller.ts
@@ -58,6 +58,9 @@ export class RafikiController implements IRafikiController {
       await this.deps.rafikiService.onWebHook(wh.body)
       res.status(200).send()
     } catch (e) {
+      this.deps.logger.error(
+        `Webhook response error for rafiki: ${(e as Error).message}`
+      )
       next(e)
     }
   }

--- a/packages/wallet/backend/src/rafiki/rafiki-client.ts
+++ b/packages/wallet/backend/src/rafiki/rafiki-client.ts
@@ -163,6 +163,9 @@ export class RafikiClient implements IRafikiClient {
     })
 
     if (!response.withdrawEventLiquidity?.success) {
+      if (response.withdrawEventLiquidity?.message === 'Transfer exists') {
+        return true
+      }
       throw new BadRequest(
         response.withdrawEventLiquidity?.message ||
           'Unable to withdrawLiquidity from rafiki'


### PR DESCRIPTION
 -closes #501 
 
 ### Context
 
 Rafiki now only fires the incoming_payment.expired Webhook if an incoming payment expires WITH money already sent in it.
Testnet makes use of this.

When we SEND TO AN EXISTING INCOMING PAYMENT, the flow is normal, and rafiki sends incoming_payment.completed.
 
When we SEND DIRECTLY TO PAYMENT POINTER, testnet backend automatically creates an incoming payment.

Note: the automatically created incoming payment **can either have an amount or not**. Depending on the send type:

- **FIXED SEND (send)**: we do not know the amount that the incoming payment should have beforehand, and as such we set the amount as null. The receiver can receive any amount.
As such, that incoming payment does not complete, since it does not get fulfilled.
But if we set the expiry as 15 seconds, and the money gets sent from the outgoing payment, rafiki will send incoming_payment.expired, and we will treat it as COMPLETED (since the money got sent)

- **FIXED DELIVERY** (receive): We do know what the incoming payment amount is, so in this case, the incoming payment will actually complete, and rafiki will send incoming_payment.completed


### Changes
The automatically created  incoming payment now has a lower expiry, set to 15 seconds -> since it is just a necessary volatile
(means to an end) and we expect it to complete during the same flow.

Testnet now logs errors that are sent back to rafiki on the webhook endpoint.
Testnet now logs all received events, for better debugging of causality.
Testnet is now aware of the payment_pointer.not_found webhook event. It does not act upon it yet.



Local deltas of incoming payment completion:

- SEND TO AN EXISTING INCOMING PAYMENT (32 seconds until incoming completed):
<img width="1212" alt="image" src="https://github.com/interledger/testnet/assets/111863110/8fa0ce97-9c47-44cf-8362-5630eb729c9e">

- FIXED SEND (send) (42 seconds until incoming expired):
<img width="1200" alt="image" src="https://github.com/interledger/testnet/assets/111863110/e19ed34e-ca75-4606-b5aa-5dd7aaa03ede">

- FIXED DELIVERY (receive) (31 seconds until incoming completed):
<img width="1206" alt="image" src="https://github.com/interledger/testnet/assets/111863110/f151cfa5-e53e-4cfb-bf19-a32bde7a3eae">

The above screenshots show the new logs, as well as the deltas that I had on my local setup when attempting all of our payment kinds.










