### PR TITLE
fix(quote): change invalid amount error

### DIFF
--- a/packages/wallet/backend/src/rafiki/rafiki-client.ts
+++ b/packages/wallet/backend/src/rafiki/rafiki-client.ts
@@ -300,8 +300,11 @@ export class RafikiClient implements IRafikiClient {
       input
     })
 
-    if (createQuote.code === '400' && createQuote.message === 'invalid amount') {
-      throw new BadRequest('Fees exceed send amount');
+    if (
+      createQuote.code === '400' &&
+      createQuote.message === 'invalid amount'
+    ) {
+      throw new BadRequest('Fees exceed send amount')
     }
 
     if (!createQuote.quote) {

--- a/packages/wallet/backend/src/rafiki/rafiki-client.ts
+++ b/packages/wallet/backend/src/rafiki/rafiki-client.ts
@@ -300,6 +300,10 @@ export class RafikiClient implements IRafikiClient {
       input
     })
 
+    if (createQuote.code === '400' && createQuote.message === 'invalid amount') {
+      throw new BadRequest('Fees exceed send amount');
+    }
+
     if (!createQuote.quote) {
       throw new Error('Unable to fetch created quote')
     }

--- a/packages/wallet/backend/src/rafiki/service.ts
+++ b/packages/wallet/backend/src/rafiki/service.ts
@@ -597,7 +597,7 @@ export class RafikiService implements IRafikiService {
       )
 
       if (receiveAmountValue <= fees) {
-        throw new BadRequest('Fees exceed quote receiveAmount')
+        this.deps.logger.debug('Fees exceed quote receiveAmount')
       }
 
       receivedQuote.receiveAmount.value = receiveAmountValue - fees


### PR DESCRIPTION
<!--
If the PR is related to an open issue(s) please provide a list of them.

Example:
    - closes (or fixes) #<issue number>
    - closes (or fixes) #<issue number>
-->

### Context

- fixes #709 

<!--
Short description of what has changed
-->

### Changes
- return the invalid amount to rafiki so it will throw an `invalid amount` error itself instead of a generic one
- transform invalid amount error to a more user friendly message

This can be improved if rafiki will allow the client to throw errors that it can handle and return an equivalent message.