### PR TITLE
chore: Update documentation with linked image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Testnet
 
-<img width="920" alt="testnet" src="https://user-images.githubusercontent.com/117268143/220323531-538238d2-f538-4ed5-be97-163e28ebc48f.jpg">
+<a href="#what-is-testnet">
+  <img src="https://user-images.githubusercontent.com/117268143/220323531-538238d2-f538-4ed5-be97-163e28ebc48f.jpg" width="920" alt="Testnet picture">
+</a>
 
 ## What is Testnet?
 


### PR DESCRIPTION
 I fixed the issue #829 that was assigned to me.
I have made the image in the readme.md liked with the heading of the file.
Earlier when we clicked on the picture, we were brought to a new tab with just the picture on it.
Now its fixed.
This is the [issue](https://github.com/interledger/testnet/issues/829)
