### PR TITLE
Add back navigation and breadcrumb

### DIFF
--- a/packages/wallet/frontend/src/components/Menu.tsx
+++ b/packages/wallet/frontend/src/components/Menu.tsx
@@ -196,10 +196,31 @@ export const Menu = () => {
       <nav className="fixed inset-x-0 z-10 flex h-20 flex-col bg-white shadow-md md:inset-y-0 md:h-auto md:w-60 md:shadow-none">
         <div className="flex min-h-0 flex-1 items-center px-6 py-10 md:flex-col md:items-start md:overflow-y-auto md:bg-gradient-primary">
           <div className="flex items-center font-semibold text-green">
-            <button className='w-4 h-4 scale-125 md:fixed md:top-3 md:left-2 flex items-center mr-5 mt-[5px] active:scale-100' onClick={() => {
-              router.push('/');
-            }}>
-              <svg xmlns="http://www.w3.org/2000/svg" xmlnsXlink="http://www.w3.org/1999/xlink" version="1.1" x="0px" y="0px" viewBox="0 0 78.415 98.02" enableBackground="new 0 0 78.415 78.416" xmlSpace="preserve"><g><g><path fill="#003A2F" d="M0,39.208c0,21.654,17.554,39.208,39.208,39.208c21.653,0,39.207-17.554,39.207-39.208S60.861,0,39.208,0    C17.554,0,0,17.554,0,39.208z M24.924,36.816l18.511-18.512c0.66-0.66,1.525-0.99,2.391-0.99s1.731,0.33,2.391,0.99    c1.316,1.319,1.32,3.458,0,4.777L32.088,39.209l16.128,16.125c1.316,1.32,1.316,3.459,0,4.777c-1.32,1.32-3.461,1.32-4.775,0    L24.924,41.598C23.604,40.278,23.604,38.136,24.924,36.816z" /></g></g></svg>
+            <button
+              className="mr-5 mt-[5px] flex h-4 w-4 scale-125 items-center active:scale-100 md:fixed md:left-2 md:top-3"
+              onClick={() => {
+                router.push('/')
+              }}
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                xmlnsXlink="http://www.w3.org/1999/xlink"
+                version="1.1"
+                x="0px"
+                y="0px"
+                viewBox="0 0 78.415 98.02"
+                enableBackground="new 0 0 78.415 78.416"
+                xmlSpace="preserve"
+              >
+                <g>
+                  <g>
+                    <path
+                      fill="#003A2F"
+                      d="M0,39.208c0,21.654,17.554,39.208,39.208,39.208c21.653,0,39.207-17.554,39.207-39.208S60.861,0,39.208,0    C17.554,0,0,17.554,0,39.208z M24.924,36.816l18.511-18.512c0.66-0.66,1.525-0.99,2.391-0.99s1.731,0.33,2.391,0.99    c1.316,1.319,1.32,3.458,0,4.777L32.088,39.209l16.128,16.125c1.316,1.32,1.316,3.459,0,4.777c-1.32,1.32-3.461,1.32-4.775,0    L24.924,41.598C23.604,40.278,23.604,38.136,24.924,36.816z"
+                    />
+                  </g>
+                </g>
+              </svg>
             </button>
             <Logo className="h-10 w-10 flex-shrink-0 md:h-16 md:w-16" />
             <div className="pl-2">

--- a/packages/wallet/frontend/src/components/Menu.tsx
+++ b/packages/wallet/frontend/src/components/Menu.tsx
@@ -196,6 +196,11 @@ export const Menu = () => {
       <nav className="fixed inset-x-0 z-10 flex h-20 flex-col bg-white shadow-md md:inset-y-0 md:h-auto md:w-60 md:shadow-none">
         <div className="flex min-h-0 flex-1 items-center px-6 py-10 md:flex-col md:items-start md:overflow-y-auto md:bg-gradient-primary">
           <div className="flex items-center font-semibold text-green">
+            <button className='w-4 h-4 scale-125 md:fixed md:top-3 md:left-2 flex items-center mr-5 mt-[5px] active:scale-100' onClick={() => {
+              router.push('/');
+            }}>
+              <svg xmlns="http://www.w3.org/2000/svg" xmlnsXlink="http://www.w3.org/1999/xlink" version="1.1" x="0px" y="0px" viewBox="0 0 78.415 98.02" enableBackground="new 0 0 78.415 78.416" xmlSpace="preserve"><g><g><path fill="#003A2F" d="M0,39.208c0,21.654,17.554,39.208,39.208,39.208c21.653,0,39.207-17.554,39.207-39.208S60.861,0,39.208,0    C17.554,0,0,17.554,0,39.208z M24.924,36.816l18.511-18.512c0.66-0.66,1.525-0.99,2.391-0.99s1.731,0.33,2.391,0.99    c1.316,1.319,1.32,3.458,0,4.777L32.088,39.209l16.128,16.125c1.316,1.32,1.316,3.459,0,4.777c-1.32,1.32-3.461,1.32-4.775,0    L24.924,41.598C23.604,40.278,23.604,38.136,24.924,36.816z" /></g></g></svg>
+            </button>
             <Logo className="h-10 w-10 flex-shrink-0 md:h-16 md:w-16" />
             <div className="pl-2">
               <div className="text-lg md:text-2xl">Interledger</div>

--- a/packages/wallet/frontend/src/components/layouts/AppLayout.tsx
+++ b/packages/wallet/frontend/src/components/layouts/AppLayout.tsx
@@ -15,8 +15,8 @@ type AppLayoutProps = {
 
 export const AppLayout = ({ children }: AppLayoutProps) => {
   const pathname = usePathname()
-  const Path = pathname.split('/');
-  let currentPath = '';
+  const Path = pathname.split('/')
+  let currentPath = ''
   const { isUserFirstTime, setIsUserFirstTime } = useOnboardingContext()
 
   useEffect(() => {
@@ -29,21 +29,22 @@ export const AppLayout = ({ children }: AppLayoutProps) => {
   return (
     <>
       <Menu />
-      <div className='fixed top-[84px] left-4 md:fixed md:top-2 md:left-64 flex text-[#003A2F] font-semibold'>
-        <Link href="/" className='underline'>Home</Link>
-        {
-          Path.filter(beta => beta != "").map((alpha, key) => {
-            currentPath += `/${alpha}`;
-            alpha = alpha.charAt(0).toUpperCase() + alpha.slice(1);
-            return (
-              <>
-                <p className='mx-1 pb-1'>{` > `}</p>
-                <Link href={currentPath} className='underline' key={key}>{alpha}</Link>
-              </>
-            )
-          })
-        }
-
+      <div className="fixed left-4 top-[84px] flex font-semibold text-[#003A2F] md:fixed md:left-64 md:top-2">
+        <Link href="/" className="underline">
+          Home
+        </Link>
+        {Path.filter((beta) => beta != '').map((alpha, key) => {
+          currentPath += `/${alpha}`
+          alpha = alpha.charAt(0).toUpperCase() + alpha.slice(1)
+          return (
+            <>
+              <p className="mx-1 pb-1">{` > `}</p>
+              <Link href={currentPath} className="underline" key={key}>
+                {alpha}
+              </Link>
+            </>
+          )
+        })}
       </div>
       {isUserFirstTime && <Onboarding />}
       <div className="flex flex-1 flex-col pt-20 md:pl-60 md:pt-0">

--- a/packages/wallet/frontend/src/components/layouts/AppLayout.tsx
+++ b/packages/wallet/frontend/src/components/layouts/AppLayout.tsx
@@ -2,7 +2,9 @@ import { ReactNode, useEffect } from 'react'
 import { Menu } from '@/components/Menu'
 import { Bubbles } from '@/ui/Bubbles'
 import dynamic from 'next/dynamic'
+import { usePathname } from 'next/navigation'
 import { useOnboardingContext } from '@/lib/context/onboarding'
+import Link from 'next/link'
 const Onboarding = dynamic(() => import('@/components/onboarding/Onboarding'), {
   ssr: false
 })
@@ -12,6 +14,9 @@ type AppLayoutProps = {
 }
 
 export const AppLayout = ({ children }: AppLayoutProps) => {
+  const pathname = usePathname()
+  const Path = pathname.split('/');
+  let currentPath = '';
   const { isUserFirstTime, setIsUserFirstTime } = useOnboardingContext()
 
   useEffect(() => {
@@ -24,6 +29,22 @@ export const AppLayout = ({ children }: AppLayoutProps) => {
   return (
     <>
       <Menu />
+      <div className='fixed top-[84px] left-4 md:fixed md:top-2 md:left-64 flex text-[#003A2F] font-semibold'>
+        <Link href="/" className='underline'>Home</Link>
+        {
+          Path.filter(beta => beta != "").map((alpha, key) => {
+            currentPath += `/${alpha}`;
+            alpha = alpha.charAt(0).toUpperCase() + alpha.slice(1);
+            return (
+              <>
+                <p className='mx-1 pb-1'>{` > `}</p>
+                <Link href={currentPath} className='underline' key={key}>{alpha}</Link>
+              </>
+            )
+          })
+        }
+
+      </div>
       {isUserFirstTime && <Onboarding />}
       <div className="flex flex-1 flex-col pt-20 md:pl-60 md:pt-0">
         <main className="flex-1">

--- a/packages/wallet/frontend/src/pages/auth/login.tsx
+++ b/packages/wallet/frontend/src/pages/auth/login.tsx
@@ -87,10 +87,31 @@ const LoginPage: NextPageWithLayout = () => {
         <Link href="signup" className="font-medium underline">
           Create an account
         </Link>
-        <button className='w-4 h-4 scale-150 flex items-center text-[#7acebe] absolute top-10 left-20' onClick={()=>{
-          router.back();
-        }}>
-          <svg xmlns="http://www.w3.org/2000/svg" xmlnsXlink="http://www.w3.org/1999/xlink" version="1.1" x="0px" y="0px" viewBox="0 0 78.415 98.02" enableBackground="new 0 0 78.415 78.416" xmlSpace="preserve"><g><g><path fill="#7acebe" d="M0,39.208c0,21.654,17.554,39.208,39.208,39.208c21.653,0,39.207-17.554,39.207-39.208S60.861,0,39.208,0    C17.554,0,0,17.554,0,39.208z M24.924,36.816l18.511-18.512c0.66-0.66,1.525-0.99,2.391-0.99s1.731,0.33,2.391,0.99    c1.316,1.319,1.32,3.458,0,4.777L32.088,39.209l16.128,16.125c1.316,1.32,1.316,3.459,0,4.777c-1.32,1.32-3.461,1.32-4.775,0    L24.924,41.598C23.604,40.278,23.604,38.136,24.924,36.816z"/></g></g></svg>
+        <button
+          className="absolute left-20 top-10 flex h-4 w-4 scale-150 items-center text-[#7acebe]"
+          onClick={() => {
+            router.back()
+          }}
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            xmlnsXlink="http://www.w3.org/1999/xlink"
+            version="1.1"
+            x="0px"
+            y="0px"
+            viewBox="0 0 78.415 98.02"
+            enableBackground="new 0 0 78.415 78.416"
+            xmlSpace="preserve"
+          >
+            <g>
+              <g>
+                <path
+                  fill="#7acebe"
+                  d="M0,39.208c0,21.654,17.554,39.208,39.208,39.208c21.653,0,39.207-17.554,39.207-39.208S60.861,0,39.208,0    C17.554,0,0,17.554,0,39.208z M24.924,36.816l18.511-18.512c0.66-0.66,1.525-0.99,2.391-0.99s1.731,0.33,2.391,0.99    c1.316,1.319,1.32,3.458,0,4.777L32.088,39.209l16.128,16.125c1.316,1.32,1.316,3.459,0,4.777c-1.32,1.32-3.461,1.32-4.775,0    L24.924,41.598C23.604,40.278,23.604,38.136,24.924,36.816z"
+                />
+              </g>
+            </g>
+          </svg>
         </button>
       </p>
     </>

--- a/packages/wallet/frontend/src/pages/auth/login.tsx
+++ b/packages/wallet/frontend/src/pages/auth/login.tsx
@@ -87,6 +87,11 @@ const LoginPage: NextPageWithLayout = () => {
         <Link href="signup" className="font-medium underline">
           Create an account
         </Link>
+        <button className='w-4 h-4 scale-150 flex items-center text-[#7acebe] absolute top-10 left-20' onClick={()=>{
+          router.back();
+        }}>
+          <svg xmlns="http://www.w3.org/2000/svg" xmlnsXlink="http://www.w3.org/1999/xlink" version="1.1" x="0px" y="0px" viewBox="0 0 78.415 98.02" enableBackground="new 0 0 78.415 78.416" xmlSpace="preserve"><g><g><path fill="#7acebe" d="M0,39.208c0,21.654,17.554,39.208,39.208,39.208c21.653,0,39.207-17.554,39.207-39.208S60.861,0,39.208,0    C17.554,0,0,17.554,0,39.208z M24.924,36.816l18.511-18.512c0.66-0.66,1.525-0.99,2.391-0.99s1.731,0.33,2.391,0.99    c1.316,1.319,1.32,3.458,0,4.777L32.088,39.209l16.128,16.125c1.316,1.32,1.316,3.459,0,4.777c-1.32,1.32-3.461,1.32-4.775,0    L24.924,41.598C23.604,40.278,23.604,38.136,24.924,36.816z"/></g></g></svg>
+        </button>
       </p>
     </>
   )


### PR DESCRIPTION
## Issue
fixes #474 

## Description

In this pull request, I've implemented two key features to enhance the user experience:

1. **Back Navigation Button**: Added a back navigation button to the user interface. This button allows users to easily return to the home page from any point in the application, improving overall navigation.

2. **Breadcrumbs**: Implemented breadcrumbs at the top of the page. Breadcrumbs provide users with a clear and intuitive trail of their navigation history. Users can now see their path and easily backtrack to previous pages, which is particularly useful for deep navigation within the application.

## Changes Made

- Created a back navigation button component with back arrow icon, making it highly visible and accessible to users.
- Integrated the back navigation functionality, ensuring it redirects users to the home page.
- Introduced breadcrumb elements at the top of each page, dynamically generated based on the user's navigation path.
- Styled the breadcrumbs for consistency with the application's design.

## Screenshots
Desktop view:
![image](https://github.com/interledger/testnet/assets/119877487/16720c63-3a7b-4f47-b6f7-88e0f5f63085)

Mobile View
![image](https://github.com/interledger/testnet/assets/119877487/4d543854-6082-44d8-adaf-4dfe074dc853)


