### PR TITLE
feat(wallet-frontend): private key copy as base 64

### DIFF
--- a/packages/wallet/frontend/src/components/settings/DeveloperKeys.tsx
+++ b/packages/wallet/frontend/src/components/settings/DeveloperKeys.tsx
@@ -285,10 +285,14 @@ const PaymentPointerCTA = () => {
                   value={privateKey}
                 />
                 <CopyButton
-                  ctaText="COPY BASE64 PRIVATE KEY"
-                  copyType="base64"
-                  aria-label="copy base64 private key"
+                  ctaText="COPY PRIVATE KEY"
+                  aria-label="copy private key"
                   value={privateKey}
+                />
+                <CopyButton
+                  ctaText="COPY BASE64 ENCODED PRIVATE KEY"
+                  aria-label="copy base64 encoded private key"
+                  value={btoa(privateKey.trim())}
                 />
               </div>
             </div>

--- a/packages/wallet/frontend/src/components/settings/DeveloperKeys.tsx
+++ b/packages/wallet/frontend/src/components/settings/DeveloperKeys.tsx
@@ -285,8 +285,9 @@ const PaymentPointerCTA = () => {
                   value={privateKey}
                 />
                 <CopyButton
-                  ctaText="COPY PRIVATE KEY"
-                  aria-label="copy private key"
+                  ctaText="COPY BASE64 PRIVATE KEY"
+                  copyType="base64"
+                  aria-label="copy base64 private key"
                   value={privateKey}
                 />
               </div>

--- a/packages/wallet/frontend/src/ui/CopyButton.tsx
+++ b/packages/wallet/frontend/src/ui/CopyButton.tsx
@@ -4,7 +4,9 @@ import { Button, ButtonProps } from './Button'
 import { cx } from 'class-variance-authority'
 
 function copyToClipboard(value: string, copyType?: string) {
-  navigator.clipboard.writeText(copyType === 'base64' ? btoa(value.trim()) : value)
+  navigator.clipboard.writeText(
+    copyType === 'base64' ? btoa(value.trim()) : value
+  )
 }
 
 type CopyButtonProps = Omit<ButtonProps, 'intent'> & {

--- a/packages/wallet/frontend/src/ui/CopyButton.tsx
+++ b/packages/wallet/frontend/src/ui/CopyButton.tsx
@@ -3,20 +3,22 @@ import { useEffect, useState } from 'react'
 import { Button, ButtonProps } from './Button'
 import { cx } from 'class-variance-authority'
 
-function copyToClipboard(value: string) {
-  navigator.clipboard.writeText(value)
+function copyToClipboard(value: string, copyType?: string) {
+  navigator.clipboard.writeText(copyType === 'base64' ? btoa(value.trim()) : value)
 }
 
 type CopyButtonProps = Omit<ButtonProps, 'intent'> & {
   value: string
   ctaText?: string
   afterCtaText?: string
+  copyType?: string
 }
 
 export const CopyButton = ({
   value,
   afterCtaText,
   ctaText,
+  copyType,
   ...props
 }: CopyButtonProps) => {
   const [isCopied, setIsCopied] = useState(false)
@@ -32,7 +34,7 @@ export const CopyButton = ({
       intent="outline"
       size="sm"
       onClick={() => {
-        copyToClipboard(value)
+        copyToClipboard(value, copyType)
         setIsCopied(true)
       }}
       {...props}

--- a/packages/wallet/frontend/src/ui/CopyButton.tsx
+++ b/packages/wallet/frontend/src/ui/CopyButton.tsx
@@ -3,24 +3,20 @@ import { useEffect, useState } from 'react'
 import { Button, ButtonProps } from './Button'
 import { cx } from 'class-variance-authority'
 
-function copyToClipboard(value: string, copyType?: string) {
-  navigator.clipboard.writeText(
-    copyType === 'base64' ? btoa(value.trim()) : value
-  )
+function copyToClipboard(value: string) {
+  navigator.clipboard.writeText(value)
 }
 
 type CopyButtonProps = Omit<ButtonProps, 'intent'> & {
   value: string
   ctaText?: string
   afterCtaText?: string
-  copyType?: string
 }
 
 export const CopyButton = ({
   value,
   afterCtaText,
   ctaText,
-  copyType,
   ...props
 }: CopyButtonProps) => {
   const [isCopied, setIsCopied] = useState(false)
@@ -36,7 +32,7 @@ export const CopyButton = ({
       intent="outline"
       size="sm"
       onClick={() => {
-        copyToClipboard(value, copyType)
+        copyToClipboard(value)
         setIsCopied(true)
       }}
       {...props}


### PR DESCRIPTION
<!--
If the PR is related to an open issue(s) please provide a list of them.

Example:
    - closes (or fixes) #<issue number>
    - closes (or fixes) #<issue number>
-->

### Context

- fixes #867 

<!--
Short description of what has changed
-->

### Changes
Change Copy Private button, to copy private button as base 64 encoded string.