### PR TITLE
fix(wallet-frontend): overflow in developer keys page

### DIFF
--- a/packages/wallet/frontend/src/components/settings/DeveloperKeys.tsx
+++ b/packages/wallet/frontend/src/components/settings/DeveloperKeys.tsx
@@ -103,7 +103,7 @@ type AccountPanelProps = {
 const AccountPanel = ({ paymentPointers }: AccountPanelProps) => {
   return (
     <Transition
-      className="overflow-hidden"
+      className="overflow-scroll px-2"
       enter="transition-all ease-in-out duration-300"
       enterFrom="transform max-h-0"
       enterTo="transform max-h-screen"


### PR DESCRIPTION


### Context

- fixes #891 

<!--
Short description of what has changed
-->

### Changes

Changed the classname from `overflow-hidden` to `overflow-scroll px-2`
