### PR TITLE
fix(deps): bump `@interledger/open-payments` to `6.1.1`

### DIFF
--- a/packages/boutique/backend/package.json
+++ b/packages/boutique/backend/package.json
@@ -6,7 +6,7 @@
     "test": "jest --passWithNoTests --maxWorkers=2"
   },
   "dependencies": {
-    "@interledger/open-payments": "^6.1.0",
+    "@interledger/open-payments": "^6.1.1",
     "awilix": "^9.0.0",
     "axios": "^1.6.2",
     "cors": "^2.8.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
   packages/boutique/backend:
     dependencies:
       '@interledger/open-payments':
-        specifier: ^6.1.0
-        version: 6.1.0
+        specifier: ^6.1.1
+        version: 6.1.1
       awilix:
         specifier: ^9.0.0
         version: 9.0.0
@@ -2124,8 +2124,8 @@ packages:
       uuid: 9.0.1
     dev: false
 
-  /@interledger/open-payments@6.1.0:
-    resolution: {integrity: sha512-M7snUtsKdPGgKx4FyUfKFC2PeWTr2qIh+8AYpBXIj90GOMOU/u7ArEBxmrVzHD7PjKyE4fKatpuwTPlyvt7pCg==}
+  /@interledger/open-payments@6.1.1:
+    resolution: {integrity: sha512-eS2zEGCuqb+WMAOzFvjCeKSRhpsIYQpFSslu4ET+jpleDn8NZJCwhW0q16f43UJJNargLeSGIg9CsKRcYRceZA==}
     dependencies:
       '@interledger/http-signature-utils': 2.0.0
       '@interledger/openapi': 1.2.1


### PR DESCRIPTION
<!--
If the PR is related to an open issue(s) please provide a list of them.

Example:
    - closes (or fixes) #<issue number>
    - closes (or fixes) #<issue number>
-->

### Context

https://github.com/interledger/open-payments/issues/378

<!--
Short description of what has changed
-->

### Changes
`@interledger/open-payments@6.1.1` fixes the `useHttp` issue. We were not able to use the SDK in a local environment.