### PR TITLE
feat(wallet-frontend): add create WM PP button to Web Monetization PP list

### DIFF
--- a/packages/wallet/frontend/src/components/dialogs/CreateWalletAddressDialog.tsx
+++ b/packages/wallet/frontend/src/components/dialogs/CreateWalletAddressDialog.tsx
@@ -17,7 +17,7 @@ import { Checkbox } from '@/ui/forms/Checkbox'
 import { TemporaryWMNotice } from '../TemporaryWMNotice'
 
 type CreateWalletAddressDialogProps = Pick<DialogProps, 'onClose'> & {
-  accountName: string,
+  accountName: string
   isChecked?: boolean
 }
 

--- a/packages/wallet/frontend/src/components/dialogs/CreateWalletAddressDialog.tsx
+++ b/packages/wallet/frontend/src/components/dialogs/CreateWalletAddressDialog.tsx
@@ -17,12 +17,14 @@ import { Checkbox } from '@/ui/forms/Checkbox'
 import { TemporaryWMNotice } from '../TemporaryWMNotice'
 
 type CreateWalletAddressDialogProps = Pick<DialogProps, 'onClose'> & {
-  accountName: string
+  accountName: string,
+  isChecked?: boolean
 }
 
 export const CreateWalletAddressDialog = ({
   onClose,
-  accountName
+  accountName,
+  isChecked
 }: CreateWalletAddressDialogProps) => {
   const router = useRouter()
   const createWalletAddressForm = useZodForm({
@@ -133,6 +135,7 @@ export const CreateWalletAddressDialog = ({
                     />
                     <Checkbox
                       label="I want to use this payment pointer for Web Monetization"
+                      checked={isChecked}
                       {...createWalletAddressForm.register('isWM')}
                     />
                     <div className="mt-5 flex flex-col justify-between space-y-3 sm:flex-row-reverse sm:space-y-0">

--- a/packages/wallet/frontend/src/components/dialogs/CreateWalletAddressDialog.tsx
+++ b/packages/wallet/frontend/src/components/dialogs/CreateWalletAddressDialog.tsx
@@ -18,13 +18,13 @@ import { TemporaryWMNotice } from '../TemporaryWMNotice'
 
 type CreateWalletAddressDialogProps = Pick<DialogProps, 'onClose'> & {
   accountName: string
-  isChecked?: boolean
+  isWebMonetization?: boolean
 }
 
 export const CreateWalletAddressDialog = ({
   onClose,
   accountName,
-  isChecked
+  isWebMonetization
 }: CreateWalletAddressDialogProps) => {
   const router = useRouter()
   const createWalletAddressForm = useZodForm({
@@ -34,6 +34,7 @@ export const CreateWalletAddressDialog = ({
   const { isUserFirstTime, setRunOnboarding, stepIndex, setStepIndex } =
     useOnboardingContext()
   const accountId = router.query.accountId as string
+  const titleExtra = isWebMonetization ? 'Web Monetization' : ''
 
   return (
     <Transition.Root show={true} as={Fragment} appear={true}>
@@ -66,7 +67,7 @@ export const CreateWalletAddressDialog = ({
                   as="h3"
                   className="text-center text-2xl font-medium text-green-6"
                 >
-                  Create Payment Pointer
+                  Create {titleExtra} Payment Pointer
                 </Dialog.Title>
 
                 <div className="px-4">
@@ -74,6 +75,7 @@ export const CreateWalletAddressDialog = ({
                   <Form
                     form={createWalletAddressForm}
                     onSubmit={async (data) => {
+                      data.isWM = isWebMonetization ? true : data.isWM
                       const response = await walletAddressService.create(
                         accountId,
                         data
@@ -135,8 +137,10 @@ export const CreateWalletAddressDialog = ({
                     />
                     <Checkbox
                       label="I want to use this payment pointer for Web Monetization"
-                      checked={isChecked}
-                      disabled={isChecked}
+                      checked={isWebMonetization}
+                      onClick={(e) => {
+                        if (isWebMonetization) e.preventDefault()
+                      }}
                       {...createWalletAddressForm.register('isWM')}
                     />
                     <div className="mt-5 flex flex-col justify-between space-y-3 sm:flex-row-reverse sm:space-y-0">

--- a/packages/wallet/frontend/src/components/dialogs/CreateWalletAddressDialog.tsx
+++ b/packages/wallet/frontend/src/components/dialogs/CreateWalletAddressDialog.tsx
@@ -136,6 +136,7 @@ export const CreateWalletAddressDialog = ({
                     <Checkbox
                       label="I want to use this payment pointer for Web Monetization"
                       checked={isChecked}
+                      disabled={isChecked}
                       {...createWalletAddressForm.register('isWM')}
                     />
                     <div className="mt-5 flex flex-col justify-between space-y-3 sm:flex-row-reverse sm:space-y-0">

--- a/packages/wallet/frontend/src/pages/account/[accountId].tsx
+++ b/packages/wallet/frontend/src/pages/account/[accountId].tsx
@@ -245,7 +245,7 @@ const AccountPage: NextPageWithLayout<AccountPageProps> = ({
                 </div>
                 <div className="my-5">
                   <button
-                    id="walletAddress"
+                    id="walletAddressWM"
                     onClick={() => {
                       openDialog(
                         <CreateWalletAddressDialog

--- a/packages/wallet/frontend/src/pages/account/[accountId].tsx
+++ b/packages/wallet/frontend/src/pages/account/[accountId].tsx
@@ -243,7 +243,7 @@ const AccountPage: NextPageWithLayout<AccountPageProps> = ({
                     </p>
                   </div>
                 </div>
-                <div className="my-5">
+                <div className="my-10">
                   <button
                     id="walletAddressWM"
                     onClick={() => {

--- a/packages/wallet/frontend/src/pages/account/[accountId].tsx
+++ b/packages/wallet/frontend/src/pages/account/[accountId].tsx
@@ -243,6 +243,34 @@ const AccountPage: NextPageWithLayout<AccountPageProps> = ({
                     </p>
                   </div>
                 </div>
+                <div className='my-5'>
+                <button
+                  id="walletAddress"
+                  onClick={() => {
+                    openDialog(
+                      <CreateWalletAddressDialog
+                        accountName={account.name}
+                        isChecked={true}
+                        onClose={closeDialog}
+                      />
+                    )
+                  }}
+                  className="group flex aspect-square h-24 w-24 flex-col items-center justify-center -space-y-1 rounded-lg border border-green-5 bg-white shadow-md hover:border-green-6"
+                >
+                  <New className="h-9 w-7" />
+                  <div className="-space-y-2 text-[15px]">
+                    <p className="font-medium text-green-5 group-hover:text-green-6">
+                      Add WM{' '}
+                    </p>
+                    <p className="font-medium text-green-5 group-hover:text-green-6">
+                      payment{' '}
+                    </p>
+                    <p className="font-medium text-green-5 group-hover:text-green-6">
+                      pointer
+                    </p>
+                  </div>
+                </button>
+                </div>
                 <div className="mt-5 flex w-full flex-col space-y-5 md:max-w-md">
                   <div className="flex items-center justify-between">
                     <h3 className="text-lg font-semibold leading-none text-green">

--- a/packages/wallet/frontend/src/pages/account/[accountId].tsx
+++ b/packages/wallet/frontend/src/pages/account/[accountId].tsx
@@ -250,7 +250,7 @@ const AccountPage: NextPageWithLayout<AccountPageProps> = ({
                       openDialog(
                         <CreateWalletAddressDialog
                           accountName={account.name}
-                          isChecked={true}
+                          isWebMonetization={true}
                           onClose={closeDialog}
                         />
                       )

--- a/packages/wallet/frontend/src/pages/account/[accountId].tsx
+++ b/packages/wallet/frontend/src/pages/account/[accountId].tsx
@@ -243,33 +243,33 @@ const AccountPage: NextPageWithLayout<AccountPageProps> = ({
                     </p>
                   </div>
                 </div>
-                <div className='my-5'>
-                <button
-                  id="walletAddress"
-                  onClick={() => {
-                    openDialog(
-                      <CreateWalletAddressDialog
-                        accountName={account.name}
-                        isChecked={true}
-                        onClose={closeDialog}
-                      />
-                    )
-                  }}
-                  className="group flex aspect-square h-24 w-24 flex-col items-center justify-center -space-y-1 rounded-lg border border-green-5 bg-white shadow-md hover:border-green-6"
-                >
-                  <New className="h-9 w-7" />
-                  <div className="-space-y-2 text-[15px]">
-                    <p className="font-medium text-green-5 group-hover:text-green-6">
-                      Add WM{' '}
-                    </p>
-                    <p className="font-medium text-green-5 group-hover:text-green-6">
-                      payment{' '}
-                    </p>
-                    <p className="font-medium text-green-5 group-hover:text-green-6">
-                      pointer
-                    </p>
-                  </div>
-                </button>
+                <div className="my-5">
+                  <button
+                    id="walletAddress"
+                    onClick={() => {
+                      openDialog(
+                        <CreateWalletAddressDialog
+                          accountName={account.name}
+                          isChecked={true}
+                          onClose={closeDialog}
+                        />
+                      )
+                    }}
+                    className="group flex aspect-square h-24 w-24 flex-col items-center justify-center -space-y-1 rounded-lg border border-green-5 bg-white shadow-md hover:border-green-6"
+                  >
+                    <New className="h-9 w-7" />
+                    <div className="-space-y-2 text-[15px]">
+                      <p className="font-medium text-green-5 group-hover:text-green-6">
+                        Add WM{' '}
+                      </p>
+                      <p className="font-medium text-green-5 group-hover:text-green-6">
+                        payment{' '}
+                      </p>
+                      <p className="font-medium text-green-5 group-hover:text-green-6">
+                        pointer
+                      </p>
+                    </div>
+                  </button>
                 </div>
                 <div className="mt-5 flex w-full flex-col space-y-5 md:max-w-md">
                   <div className="flex items-center justify-between">


### PR DESCRIPTION
<!--
If the PR is related to an open issue(s) please provide a list of them.

Example:
    - closes (or fixes) #<issue number>
    - closes (or fixes) #<issue number>
-->

### Context

- fixes #1059 

<!--
Short description of what has changed
-->

### Changes
Added a new button on the Account Web monetization tab  payment pointer list, in order to create a WM PP directly from there as well, and not have to go back to the priginal PP list.