### PR TITLE
feat(upgrade): upgrade to alpha 8

### DIFF
--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -90,7 +90,7 @@ services:
   # Rafiki
   rafiki-auth:
     container_name: rafiki-auth
-    image: ghcr.io/interledger/rafiki-auth:v1.0.0-alpha.7
+    image: ghcr.io/interledger/rafiki-auth:v1.0.0-alpha.8
     restart: always
     networks:
       - testnet
@@ -113,7 +113,7 @@ services:
 
   rafiki-backend:
     container_name: rafiki-backend
-    image: ghcr.io/interledger/rafiki-backend:v1.0.0-alpha.7
+    image: ghcr.io/interledger/rafiki-backend:v1.0.0-alpha.8
     restart: always
     privileged: true
     volumes:
@@ -159,7 +159,7 @@ services:
 
   rafiki-frontend:
     container_name: rafiki-frontend
-    image: ghcr.io/interledger/rafiki-frontend:v1.0.0-alpha.7
+    image: ghcr.io/interledger/rafiki-frontend:v1.0.0-alpha.8
     depends_on:
       - rafiki-backend
     restart: always

--- a/docker/prod/docker-compose.yml
+++ b/docker/prod/docker-compose.yml
@@ -119,7 +119,7 @@ services:
     <<: *logging
 
   rafiki-auth:
-    image: ghcr.io/interledger/rafiki-auth:v1.0.0-alpha.7
+    image: ghcr.io/interledger/rafiki-auth:v1.0.0-alpha.8
     container_name: rafiki-auth
     environment:
       NODE_ENV: ${NODE_ENV}
@@ -143,7 +143,7 @@ services:
     <<: *logging
 
   rafiki-backend:
-    image: ghcr.io/interledger/rafiki-backend:v1.0.0-alpha.7
+    image: ghcr.io/interledger/rafiki-backend:v1.0.0-alpha.8
     container_name: rafiki-backend
     depends_on:
       - postgres
@@ -190,7 +190,7 @@ services:
     <<: *logging
 
   rafiki-frontend:
-    image: ghcr.io/interledger/rafiki-frontend:v1.0.0-alpha.7
+    image: ghcr.io/interledger/rafiki-frontend:v1.0.0-8
     container_name: rafiki-frontend
     depends_on:
       - rafiki-backend

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "pnpm": "^8.15.6",
     "npm": "pnpm",
     "yarn": "pnpm",
-    "node": "^18.14.0"
+    "node": "^20.12.1"
   },
   "private": true,
   "packageManager": "pnpm@8.15.6"

--- a/packages/boutique/backend/package.json
+++ b/packages/boutique/backend/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@google-cloud/logging-winston": "^6.0.0",
-    "@interledger/open-payments": "^6.7.1",
+    "@interledger/open-payments": "^6.8.0",
     "@shared/backend": "workspace:*",
     "awilix": "^10.0.2",
     "axios": "^1.6.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(winston@3.13.0)
       '@interledger/open-payments':
-        specifier: ^6.7.1
-        version: 6.7.1
+        specifier: ^6.8.0
+        version: 6.8.2
       '@shared/backend':
         specifier: workspace:*
         version: link:../../shared/backend
@@ -104,7 +104,7 @@ importers:
         version: 1.14.1
       ts-jest:
         specifier: ^29.1.2
-        version: 29.1.2(@babel/core@7.24.3)(jest@29.7.0)(typescript@5.4.4)
+        version: 29.1.2(@babel/core@7.23.0)(jest@29.7.0)(typescript@5.4.4)
       tsc-alias:
         specifier: ^1.8.8
         version: 1.8.8
@@ -502,7 +502,7 @@ packages:
     engines: {node: '>= 16'}
     dependencies:
       '@jsdevtools/ono': 7.1.3
-      '@types/json-schema': 7.0.13
+      '@types/json-schema': 7.0.15
       '@types/lodash.clonedeep': 4.5.7
       js-yaml: 4.1.0
       lodash.clonedeep: 4.5.0
@@ -2742,11 +2742,11 @@ packages:
       uuid: 9.0.1
     dev: false
 
-  /@interledger/open-payments@6.7.1:
-    resolution: {integrity: sha512-wrSe0Z9ogn6WpLvZQTnacyTBbHbiiXP78anAxQsPAvXh2degj82RSQJiSboSAWkC4yYPyIu7JMo3PVGC0ZTl2w==}
+  /@interledger/open-payments@6.8.2:
+    resolution: {integrity: sha512-cmStkekYm1aSLQAMl38CqOUTpkP0ydXUFrXfH7MQtZvIu1bdHzLjpqzYSiuBei1C2rf5MKIflQmTxR/mlaAEpA==}
     dependencies:
       '@interledger/http-signature-utils': 2.0.2
-      '@interledger/openapi': 1.2.1
+      '@interledger/openapi': 2.0.1
       axios: 1.6.8
       base64url: 3.0.1
       http-message-signatures: 0.1.2
@@ -2757,8 +2757,8 @@ packages:
       - supports-color
     dev: false
 
-  /@interledger/openapi@1.2.1:
-    resolution: {integrity: sha512-CVEMjLH94svT5ikaojplgZ3YlZAe7ml6G6bt0ZCbqkbwHszUwY1E6RexZZejiGju5QvwS/6Jl/Op5ymv/ECaLg==}
+  /@interledger/openapi@2.0.1:
+    resolution: {integrity: sha512-eS5mzfb6sHa0M3YvlYl1ahlTQn7Jng2VF++agS5XeL93ZrFnSaniyARNdLU0r/tJcUQxKLVSCcoKn84mU9X+pg==}
     dependencies:
       '@apidevtools/json-schema-ref-parser': 10.1.0
       ajv: 8.12.0
@@ -4364,13 +4364,8 @@ packages:
     resolution: {integrity: sha512-ACTuifTSIIbyksx2HTon3aFtCKWcID7/h3XEmRpDYdMCXxPbl+m9GteOJeaAkiAta/NJaSFuA7ahZ0NkwajDSw==}
     dev: true
 
-  /@types/json-schema@7.0.13:
-    resolution: {integrity: sha512-RbSSoHliUbnXj3ny0CNFOoxrIDV6SUGyStHsvDqosw6CkdPV8TtWGlfecuK4ToyMEAql6pzNxgCFKanovUzlgQ==}
-    dev: false
-
   /@types/json-schema@7.0.15:
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
-    dev: true
 
   /@types/json-stable-stringify@1.0.34:
     resolution: {integrity: sha512-s2cfwagOQAS8o06TcwKfr9Wx11dNGbH2E9vJz1cqV+a/LOyhWNLUNd6JSRYNzvB4d29UuJX2M0Dj9vE1T8fRXw==}
@@ -11085,6 +11080,40 @@ packages:
 
   /ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  /ts-jest@29.1.2(@babel/core@7.23.0)(jest@29.7.0)(typescript@5.4.4):
+    resolution: {integrity: sha512-br6GJoH/WUX4pu7FbZXuWGKGNDuU7b8Uj77g/Sp7puZV6EXzuByl6JrECvm0MzVzSTkSHWTihsXt+5XYER5b+g==}
+    engines: {node: ^16.10.0 || ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@babel/core': '>=7.0.0-beta.0 <8'
+      '@jest/types': ^29.0.0
+      babel-jest: ^29.0.0
+      esbuild: '*'
+      jest: ^29.0.0
+      typescript: '>=4.3 <6'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@jest/types':
+        optional: true
+      babel-jest:
+        optional: true
+      esbuild:
+        optional: true
+    dependencies:
+      '@babel/core': 7.23.0
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      jest: 29.7.0(@types/node@18.18.3)
+      jest-util: 29.7.0
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.6.0
+      typescript: 5.4.4
+      yargs-parser: 21.1.1
+    dev: true
 
   /ts-jest@29.1.2(@babel/core@7.24.3)(jest@29.7.0)(typescript@5.4.4):
     resolution: {integrity: sha512-br6GJoH/WUX4pu7FbZXuWGKGNDuU7b8Uj77g/Sp7puZV6EXzuByl6JrECvm0MzVzSTkSHWTihsXt+5XYER5b+g==}


### PR DESCRIPTION
This PR upgrades testnet to rafiki alpha-8
& upgrades node version to 20.12.1 (current iron lts)