### PR TITLE
chore: fixed pnpm version

### DIFF
--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: pnpm/action-setup@v3
         with:
-          version: latest
+          version: v9.1.4
       - uses: actions/setup-node@v4
         with:
           node-version: '20'


### PR DESCRIPTION
This PR implies having a fixed value for pnpm version

This came up after a discussion on a [feature PR](https://github.com/interledger/testnet/pull/1355#discussion_r1616867057):

Having pnpm version at latest would force feature PR's to also either update pnpm themselves, or to merge pnpm update beforehand.

I suggest we do the pnpm updates manually, preferably at the same time with upgrading Rafiki, keeping our version on par with the one used in that codebase.

