### PR TITLE
fix: add tooltip to send receive

### DIFF
--- a/packages/wallet/frontend/src/components/icons/Info.tsx
+++ b/packages/wallet/frontend/src/components/icons/Info.tsx
@@ -1,0 +1,22 @@
+import { SVGProps } from 'react'
+
+export const Info = (props: SVGProps<SVGSVGElement>) => {
+  return (
+    <svg
+      aria-hidden="true"
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      fill="none"
+      viewBox="0 0 24 24"
+      {...props}
+    >
+      <path
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M10 11h2v5m-2 0h4m-2.592-8.5h.01M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+      />
+    </svg>
+  )
+}

--- a/packages/wallet/frontend/src/styles/main.css
+++ b/packages/wallet/frontend/src/styles/main.css
@@ -25,3 +25,11 @@
 #nprogress .bar {
   @apply fixed right-0 top-0 z-[1000] h-1.5 w-full bg-pink;
 }
+
+.tooltip {
+  @apply invisible absolute;
+}
+
+.has-tooltip:hover .tooltip {
+  @apply visible z-50;
+}

--- a/packages/wallet/frontend/src/ui/TogglePayment.tsx
+++ b/packages/wallet/frontend/src/ui/TogglePayment.tsx
@@ -1,3 +1,4 @@
+import { Info } from '@/components/icons/Info'
 import { PAYMENT_RECEIVE, PAYMENT_SEND } from '@/utils/constants'
 import { Switch } from '@headlessui/react'
 import { cx } from 'class-variance-authority'
@@ -72,6 +73,16 @@ export const TogglePayment = ({
         >
           {PAYMENT_RECEIVE}
         </Switch.Label>
+        <div className="has-tooltip">
+          <Info className="ml-2 h-6 w-6 cursor-pointer text-green-3" />
+          <span className="tooltip -ml-10 min-w-36 max-w-80 rounded border border-turqoise bg-white p-2 text-sm shadow-lg">
+            You have to pay some fees in order to send payments.
+            &apos;receive&apos; means that the receiver will get the exact
+            amount from the input and you will be paying a small fee in addition
+            to that. &apos;send&apos; means that the fees will be deducted from
+            the amount in the input, and receiver will get the rest.
+          </span>
+        </div>
       </div>
     </Switch.Group>
   )


### PR DESCRIPTION
<!--
If the PR is related to an open issue(s) please provide a list of them.

Example:
    - closes (or fixes) #<issue number>
    - closes (or fixes) #<issue number>
-->

### Context

- fixes #1319 

<!--
Short description of what has changed
-->

### Changes
- added a tooltip for the send/receive toggle, the text is the same as in the oboarding