### PR TITLE
feat(wallet/frontend): add temporary card service

### DIFF
--- a/packages/wallet/frontend/src/lib/api/card.ts
+++ b/packages/wallet/frontend/src/lib/api/card.ts
@@ -1,0 +1,130 @@
+import {
+  getError,
+  httpClient,
+  type ErrorResponse,
+  type SuccessResponse
+} from '../httpClient'
+
+// TODO: update interface - can be moved to shared folder as well
+export interface IUserCard {
+  name: string
+  number: string
+  expiry: string
+  cvv: string
+  isFrozen: boolean
+}
+
+type GetDetailsResponse = SuccessResponse<IUserCard>
+type GetDetailsResult = GetDetailsResponse | ErrorResponse
+
+type TerminateCardResult = SuccessResponse | ErrorResponse
+
+type FreezeResult = SuccessResponse | ErrorResponse
+
+type UnfreezeResult = SuccessResponse | ErrorResponse
+
+type UpdateSpendingLimitResult = SuccessResponse | ErrorResponse
+
+type ChangePinResult = SuccessResponse | ErrorResponse
+
+interface UserCardService {
+  getDetails(cookies?: string): Promise<GetDetailsResult>
+  terminate(): Promise<TerminateCardResult>
+  freeze(): Promise<FreezeResult>
+  unfreeze(): Promise<UnfreezeResult>
+  updateSpendingLimit(): Promise<UpdateSpendingLimitResult>
+  changePin(): Promise<ChangePinResult>
+}
+
+const createCardService = (): UserCardService => ({
+  async getDetails(cookies) {
+    try {
+      const response = await httpClient
+        .get(`card`, {
+          headers: {
+            ...(cookies ? { Cookie: cookies } : {})
+          }
+        })
+        .json<GetDetailsResponse>()
+      return response
+    } catch (error) {
+      return getError(
+        error,
+        '[TODO] UPDATE ME!'
+      )
+    }
+  },
+
+  async terminate() {
+    try {
+      const response = await httpClient
+        .post('card/terminate')
+        .json<SuccessResponse>()
+      return response
+    } catch (error) {
+      return getError(
+        error,
+        '[TODO] UPDATE ME!'
+      )
+    }
+  },
+
+  async freeze() {
+    try {
+      const response = await httpClient
+        .post('card/freeze')
+        .json<SuccessResponse>()
+      return response
+    } catch (error) {
+      return getError(
+        error,
+        '[TODO] UPDATE ME!'
+      )
+    }
+  },
+
+  async unfreeze() {
+    try {
+      const response = await httpClient
+        .post('card/unfreeze')
+        .json<SuccessResponse>()
+      return response
+    } catch (error) {
+      return getError(
+        error,
+        '[TODO] UPDATE ME!'
+      )
+    }
+  },
+
+  async updateSpendingLimit() {
+    try {
+      const response = await httpClient
+        .post('card/update-spending-limit')
+        .json<SuccessResponse>()
+      return response
+    } catch (error) {
+      return getError(
+        error,
+        '[TODO] UPDATE ME!'
+      )
+    }
+  },
+
+  async changePin() {
+    try {
+      const response = await httpClient
+        .post('card/change-pin')
+        .json<SuccessResponse>()
+      return response
+    } catch (error) {
+      return getError(
+        error,
+        '[TODO] UPDATE ME!'
+      )
+    }
+  },
+})
+
+const cardService = createCardService()
+export { cardService }

--- a/packages/wallet/frontend/src/lib/api/card.ts
+++ b/packages/wallet/frontend/src/lib/api/card.ts
@@ -10,7 +10,7 @@ export interface IUserCard {
   name: string
   number: string
   expiry: string
-  cvv: number 
+  cvv: number
   isFrozen: boolean
 }
 

--- a/packages/wallet/frontend/src/lib/api/card.ts
+++ b/packages/wallet/frontend/src/lib/api/card.ts
@@ -10,18 +10,18 @@ export interface IUserCard {
   name: string
   number: string
   expiry: string
-  cvv: string
+  cvv: number 
   isFrozen: boolean
 }
 
 type GetDetailsResponse = SuccessResponse<IUserCard>
 type GetDetailsResult = GetDetailsResponse | ErrorResponse
 
-type TerminateCardResult = SuccessResponse | ErrorResponse
+type TerminateCardResult = SuccessResponse<boolean> | ErrorResponse
 
-type FreezeResult = SuccessResponse | ErrorResponse
+type FreezeResult = SuccessResponse<boolean> | ErrorResponse
 
-type UnfreezeResult = SuccessResponse | ErrorResponse
+type UnfreezeResult = SuccessResponse<boolean> | ErrorResponse
 
 type UpdateSpendingLimitResult = SuccessResponse | ErrorResponse
 
@@ -48,10 +48,7 @@ const createCardService = (): UserCardService => ({
         .json<GetDetailsResponse>()
       return response
     } catch (error) {
-      return getError(
-        error,
-        '[TODO] UPDATE ME!'
-      )
+      return getError(error, '[TODO] UPDATE ME!')
     }
   },
 
@@ -62,10 +59,7 @@ const createCardService = (): UserCardService => ({
         .json<SuccessResponse>()
       return response
     } catch (error) {
-      return getError(
-        error,
-        '[TODO] UPDATE ME!'
-      )
+      return getError(error, '[TODO] UPDATE ME!')
     }
   },
 
@@ -76,10 +70,7 @@ const createCardService = (): UserCardService => ({
         .json<SuccessResponse>()
       return response
     } catch (error) {
-      return getError(
-        error,
-        '[TODO] UPDATE ME!'
-      )
+      return getError(error, '[TODO] UPDATE ME!')
     }
   },
 
@@ -90,10 +81,7 @@ const createCardService = (): UserCardService => ({
         .json<SuccessResponse>()
       return response
     } catch (error) {
-      return getError(
-        error,
-        '[TODO] UPDATE ME!'
-      )
+      return getError(error, '[TODO] UPDATE ME!')
     }
   },
 
@@ -104,10 +92,7 @@ const createCardService = (): UserCardService => ({
         .json<SuccessResponse>()
       return response
     } catch (error) {
-      return getError(
-        error,
-        '[TODO] UPDATE ME!'
-      )
+      return getError(error, '[TODO] UPDATE ME!')
     }
   },
 
@@ -118,13 +103,73 @@ const createCardService = (): UserCardService => ({
         .json<SuccessResponse>()
       return response
     } catch (error) {
-      return getError(
-        error,
-        '[TODO] UPDATE ME!'
-      )
+      return getError(error, '[TODO] UPDATE ME!')
+    }
+  }
+})
+
+const mock = (): UserCardService => ({
+  async getDetails() {
+    return Promise.resolve({
+      success: true,
+      message: 'Mocked getDetails',
+      result: {
+        name: 'John Doe',
+        number: '4242 4242 4242 4242',
+        expiry: '01/27',
+        cvv: 321,
+        isFrozen: Math.random() > 0.5 ? true : false
+      }
+    })
+  },
+
+  async terminate() {
+    return Promise.resolve({
+      success: true,
+      message: 'Mocked terminate',
+      result: true
+    })
+  },
+
+  async freeze() {
+    return Promise.resolve({
+      success: true,
+      message: 'Mocked freeze',
+      result: true
+    })
+  },
+
+  async unfreeze() {
+    return Promise.resolve({
+      success: true,
+      message: 'Mocked unfreeze',
+      result: true
+    })
+  },
+
+  async updateSpendingLimit() {
+    try {
+      const response = await httpClient
+        .post('card/update-spending-limit')
+        .json<SuccessResponse>()
+      return response
+    } catch (error) {
+      return getError(error, '[TODO] UPDATE ME!')
     }
   },
+
+  async changePin() {
+    try {
+      const response = await httpClient
+        .post('card/change-pin')
+        .json<SuccessResponse>()
+      return response
+    } catch (error) {
+      return getError(error, '[TODO] UPDATE ME!')
+    }
+  }
 })
 
 const cardService = createCardService()
-export { cardService }
+const cardServiceMock = mock()
+export { cardService, cardServiceMock }

--- a/packages/wallet/frontend/src/pages/card/index.tsx
+++ b/packages/wallet/frontend/src/pages/card/index.tsx
@@ -14,6 +14,7 @@ function CardContainer() {
     </div>
   )
 }
+
 const UserCardPage: NextPageWithLayout = () => {
   return (
     <>


### PR DESCRIPTION
<!--
If the PR is related to an open issue(s) please provide a list of them.

Example:
    - closes (or fixes) #<issue number>
    - closes (or fixes) #<issue number>
-->

### Context

- Part of #1506

<!--
Short description of what has changed
-->

### Changes
- Adds initial card service for the wallet frontend
- Adds a mock service that simulates a successful API call

> [!NOTE]
> **Not the final state of the service!**
>
> This is introduced so we can prototype faster on the frontend by simulating API calls to the backend. Once the wallet endpoints are added (all or one by one, the card service will have to be updated).