### PR TITLE
fix(wallet/backend): send managed user id when retrieving wallet balance

### DIFF
--- a/packages/wallet/backend/src/account/service.ts
+++ b/packages/wallet/backend/src/account/service.ts
@@ -162,9 +162,19 @@ export class AccountService implements IAccountService {
   }
 
   async getAccountBalance(account: Account): Promise<number> {
+    const user = await User.query()
+      .findById(account.userId)
+      .select('gateHubUserId')
+
+    if (!user || !user.gateHubUserId) {
+      throw new NotFound()
+    }
+
     const balances = await this.gateHubClient.getWalletBalance(
-      account.gateHubWalletId
+      account.gateHubWalletId,
+      user.gateHubUserId
     )
+
     return Number(
       balances.find((balance) => balance.vault.asset_code === account.assetCode)
         ?.total ?? 0

--- a/packages/wallet/backend/src/gatehub/client.ts
+++ b/packages/wallet/backend/src/gatehub/client.ts
@@ -267,10 +267,15 @@ export class GateHubClient {
     return response
   }
 
-  async getWalletBalance(walletId: string): Promise<IWalletBalance[]> {
+  async getWalletBalance(
+    walletId: string,
+    managedUserUuid: string
+  ): Promise<IWalletBalance[]> {
     const url = `${this.apiUrl}/core/v1/wallets/${walletId}/balances`
 
-    const response = await this.request<IWalletBalance[]>('GET', url)
+    const response = await this.request<IWalletBalance[]>('GET', url, '', {
+      managedUserUuid
+    })
 
     return response
   }


### PR DESCRIPTION
<!--
If the PR is related to an open issue(s) please provide a list of them.

Example:
    - closes (or fixes) #<issue number>
    - closes (or fixes) #<issue number>
-->

### Context

We were receiving `403` when trying to fetch the account balance.

<!--
Short description of what has changed
-->

### Changes
- Updates `getWalletBalance` method to accept the managed user ID as well.
- Retrieve GH user ID from database when calling `accountService.list` and pass it to `getWalletBalance`