### PR TITLE
feat(boutique-frontend): change default of dark theme to light theme

### DIFF
--- a/packages/boutique/frontend/src/components/theme-provider.tsx
+++ b/packages/boutique/frontend/src/components/theme-provider.tsx
@@ -6,7 +6,7 @@ type ThemeProviderProps = {
 }
 
 export const ThemeProvider = ({ children }: ThemeProviderProps) => {
-  const [theme, setTheme] = useState<'light' | 'dark'>('dark')
+  const [theme, setTheme] = useState<'light' | 'dark'>('light')
 
   return (
     <ThemeContext.Provider


### PR DESCRIPTION
change default of dark theme to light theme for test deployment,
since imageDark is used as imageUrl in productCards, but no imageDark is in backend response atm