### PR TITLE
feat(wallet-frontend): allow receiver in query params

### DIFF
--- a/packages/wallet/frontend/src/pages/send.tsx
+++ b/packages/wallet/frontend/src/pages/send.tsx
@@ -37,6 +37,7 @@ import { ExchangeRate } from '@/components/ExchangeRate'
 import { useSnapshot } from 'valtio'
 import { balanceState } from '@/lib/balance'
 import { AssetOP } from '@wallet/shared'
+import { useRouter } from 'next/router'
 
 type SendProps = InferGetServerSidePropsType<typeof getServerSideProps>
 
@@ -50,6 +51,9 @@ const SendPage: NextPageWithLayout<SendProps> = ({ accounts }) => {
   const [receiverAssetCode, setReceiverAssetCode] = useState<string | null>(
     null
   )
+  const router = useRouter()
+  const receiverFromQueryParams = router.query?.receiver ? decodeURIComponent(router.query.receiver as string) : null;
+
   const [receiverPublicName, setReceiverPublicName] = useState('Recepient')
   const [currentExchangeRates, setCurrentExchangeRates] =
     useState<ExchangeRates>()
@@ -80,7 +84,7 @@ const SendPage: NextPageWithLayout<SendProps> = ({ accounts }) => {
     schema: sendSchema,
     defaultValues: {
       paymentType: PAYMENT_SEND,
-      receiver: isUserFirstTime ? INTERLEDGER_WALLET_ADDRESS : ''
+      receiver: receiverFromQueryParams ?? (isUserFirstTime ? INTERLEDGER_WALLET_ADDRESS : '')
     }
   })
 

--- a/packages/wallet/frontend/src/pages/send.tsx
+++ b/packages/wallet/frontend/src/pages/send.tsx
@@ -52,7 +52,9 @@ const SendPage: NextPageWithLayout<SendProps> = ({ accounts }) => {
     null
   )
   const router = useRouter()
-  const receiverFromQueryParams = router.query?.receiver ? decodeURIComponent(router.query.receiver as string) : null;
+  const receiverFromQueryParams = router.query?.receiver
+    ? decodeURIComponent(router.query.receiver as string)
+    : null
 
   const [receiverPublicName, setReceiverPublicName] = useState('Recepient')
   const [currentExchangeRates, setCurrentExchangeRates] =
@@ -84,7 +86,9 @@ const SendPage: NextPageWithLayout<SendProps> = ({ accounts }) => {
     schema: sendSchema,
     defaultValues: {
       paymentType: PAYMENT_SEND,
-      receiver: receiverFromQueryParams ?? (isUserFirstTime ? INTERLEDGER_WALLET_ADDRESS : '')
+      receiver:
+        receiverFromQueryParams ??
+        (isUserFirstTime ? INTERLEDGER_WALLET_ADDRESS : '')
     }
   })
 


### PR DESCRIPTION
<!--
If the PR is related to an open issue(s) please provide a list of them.

Example:
    - closes (or fixes) #<issue number>
    - closes (or fixes) #<issue number>
-->



### Context

- fixes #1778 

<!--
Short description of what has changed
-->

### Changes

Allows adding `receiver` to the query params of the "Send" page, which auto-populates the receiver field in the form.
