### PR TITLE
fix: 1902 callback url is not preserved

### DIFF
--- a/packages/wallet/frontend/src/middleware.ts
+++ b/packages/wallet/frontend/src/middleware.ts
@@ -11,6 +11,7 @@ const isPublicPath = (path: string) => {
 const publicPaths = ['/auth*']
 
 export async function middleware(req: NextRequest) {
+  const callbackUrl = req.nextUrl.searchParams.get('callbackUrl')
   const isPublic = isPublicPath(req.nextUrl.pathname)
   const cookieName = process.env.COOKIE_NAME || 'testnet.cookie'
 
@@ -39,7 +40,7 @@ export async function middleware(req: NextRequest) {
     }
 
     if (isPublic) {
-      return NextResponse.redirect(new URL('/', req.url))
+      return NextResponse.redirect(new URL(callbackUrl ?? '/', req.url))
     }
   } else {
     // If the user is not logged in and tries to access a private resource,

--- a/packages/wallet/frontend/src/pages/auth/login.tsx
+++ b/packages/wallet/frontend/src/pages/auth/login.tsx
@@ -73,27 +73,28 @@ const LoginPage: NextPageWithLayout = () => {
   }
 
   function handleNavigation() {
-    const isIncorrectCallbackUrl = !callbackPath.startsWith('/') &&
+    const isIncorrectCallbackUrl =
+      !callbackPath.startsWith('/') &&
       !callbackPath.startsWith(window.location.origin)
     isIncorrectCallbackUrl
       ? router.push('/')
-      : router.push(callbackPath)
-        .catch(() => router.push('/'))
+      : router.push(callbackPath).catch(() => router.push('/'))
   }
-  
+
   function togglePasswordVisibility() {
     setPasswordVisible(!isPasswordVisible)
   }
 
   useEffect(() => {
     if (callbackUrl === '/') {
-      const urlFromStorage = sessionStorage.getItem(SessionStorageKeys.CallbackUrl)
-      setCallbackPath(urlFromStorage ?? '/');
+      const urlFromStorage = sessionStorage.getItem(
+        SessionStorageKeys.CallbackUrl
+      )
+      setCallbackPath(urlFromStorage ?? '/')
     } else {
       sessionStorage.setItem(SessionStorageKeys.CallbackUrl, callbackUrl)
       setCallbackPath(callbackUrl)
     }
-
   }, [callbackUrl])
 
   useEffect(() => {
@@ -107,10 +108,7 @@ const LoginPage: NextPageWithLayout = () => {
         Login
       </h2>
       <div className="w-2/3">
-        <Form
-          form={loginForm}
-          onSubmit={(data) => submitForm(data)}
-        >
+        <Form form={loginForm} onSubmit={(data) => submitForm(data)}>
           {loginForm.formState.errors.email ? (
             <Link
               onClick={() => {

--- a/packages/wallet/frontend/src/pages/auth/login.tsx
+++ b/packages/wallet/frontend/src/pages/auth/login.tsx
@@ -91,6 +91,7 @@ const LoginPage: NextPageWithLayout = () => {
       setCallbackPath(urlFromStorage ?? '/');
     } else {
       sessionStorage.setItem(SessionStorageKeys.CallbackUrl, callbackUrl)
+      setCallbackPath(callbackUrl)
     }
 
   }, [callbackUrl])

--- a/packages/wallet/frontend/src/ui/ButtonOrLink.tsx
+++ b/packages/wallet/frontend/src/ui/ButtonOrLink.tsx
@@ -15,8 +15,9 @@ export const ButtonOrLink = forwardRef<
     return <Link href={href} ref={ref} {...props} />
   }
 
-  if (isHTMLButtonElement(ref, isLink))
+  if (isHTMLButtonElement(ref, isLink)) {
     return <button {...props} type={props.type ?? 'button'} ref={ref} />
+  }
 })
 
 ButtonOrLink.displayName = 'ButtonOrLink'
@@ -25,12 +26,12 @@ function isHTMLAnchorElement(
   ref: unknown,
   isLink: boolean
 ): ref is ForwardedRef<HTMLAnchorElement> {
-  return isLink
+  return !!ref && isLink
 }
 
 function isHTMLButtonElement(
   ref: unknown,
   isLink: boolean
 ): ref is ForwardedRef<HTMLButtonElement> {
-  return !isLink
+  return !!ref && !isLink
 }

--- a/packages/wallet/frontend/src/ui/ButtonOrLink.tsx
+++ b/packages/wallet/frontend/src/ui/ButtonOrLink.tsx
@@ -21,6 +21,8 @@ export const ButtonOrLink = forwardRef<
   if (!ref && isLink) {
     return <Link href={href} {...props} />
   }
+  
+  return <button {...props} type={props.type ?? 'button'}/>
 })
 
 ButtonOrLink.displayName = 'ButtonOrLink'

--- a/packages/wallet/frontend/src/ui/ButtonOrLink.tsx
+++ b/packages/wallet/frontend/src/ui/ButtonOrLink.tsx
@@ -21,8 +21,8 @@ export const ButtonOrLink = forwardRef<
   if (!ref && isLink) {
     return <Link href={href} {...props} />
   }
-  
-  return <button {...props} type={props.type ?? 'button'}/>
+
+  return <button {...props} type={props.type ?? 'button'} />
 })
 
 ButtonOrLink.displayName = 'ButtonOrLink'

--- a/packages/wallet/frontend/src/ui/ButtonOrLink.tsx
+++ b/packages/wallet/frontend/src/ui/ButtonOrLink.tsx
@@ -1,5 +1,5 @@
 import { forwardRef } from 'react'
-import type { ComponentPropsWithoutRef } from 'react'
+import type { ComponentPropsWithoutRef, ForwardedRef } from 'react'
 import Link from 'next/link'
 
 export type ButtonOrLinkProps = ComponentPropsWithoutRef<'button'> &
@@ -8,15 +8,27 @@ export type ButtonOrLinkProps = ComponentPropsWithoutRef<'button'> &
 export const ButtonOrLink = forwardRef<
   HTMLButtonElement | HTMLAnchorElement,
   ButtonOrLinkProps
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
->(({ href, ...props }, ref: any) => {
+>(({ href, ...props }, ref) => {
   const isLink = typeof href !== 'undefined'
 
-  if (isLink) {
+  if (isLink && isHTMLAnchorElement(ref, isLink)) {
     return <Link href={href} ref={ref} {...props} />
   }
 
-  return <button {...props} type={props.type ?? 'button'} ref={ref} />
+  if (isHTMLButtonElement(ref, isLink))
+    return <button {...props} type={props.type ?? 'button'} ref={ref} />
+
 })
 
 ButtonOrLink.displayName = 'ButtonOrLink'
+
+
+function isHTMLAnchorElement(ref: unknown, isLink: boolean): ref is ForwardedRef<HTMLAnchorElement> {
+  return isLink
+}
+
+
+function isHTMLButtonElement(ref: unknown, isLink: boolean): ref is ForwardedRef<HTMLButtonElement> {
+  return !isLink
+}
+

--- a/packages/wallet/frontend/src/ui/ButtonOrLink.tsx
+++ b/packages/wallet/frontend/src/ui/ButtonOrLink.tsx
@@ -10,13 +10,16 @@ export const ButtonOrLink = forwardRef<
   ButtonOrLinkProps
 >(({ href, ...props }, ref) => {
   const isLink = typeof href !== 'undefined'
-
   if (isLink && isHTMLAnchorElement(ref, isLink)) {
     return <Link href={href} ref={ref} {...props} />
   }
 
   if (isHTMLButtonElement(ref, isLink)) {
     return <button {...props} type={props.type ?? 'button'} ref={ref} />
+  }
+
+  if (!ref && isLink) {
+    return <Link href={href} {...props} />
   }
 })
 

--- a/packages/wallet/frontend/src/ui/ButtonOrLink.tsx
+++ b/packages/wallet/frontend/src/ui/ButtonOrLink.tsx
@@ -17,18 +17,20 @@ export const ButtonOrLink = forwardRef<
 
   if (isHTMLButtonElement(ref, isLink))
     return <button {...props} type={props.type ?? 'button'} ref={ref} />
-
 })
 
 ButtonOrLink.displayName = 'ButtonOrLink'
 
-
-function isHTMLAnchorElement(ref: unknown, isLink: boolean): ref is ForwardedRef<HTMLAnchorElement> {
+function isHTMLAnchorElement(
+  ref: unknown,
+  isLink: boolean
+): ref is ForwardedRef<HTMLAnchorElement> {
   return isLink
 }
 
-
-function isHTMLButtonElement(ref: unknown, isLink: boolean): ref is ForwardedRef<HTMLButtonElement> {
+function isHTMLButtonElement(
+  ref: unknown,
+  isLink: boolean
+): ref is ForwardedRef<HTMLButtonElement> {
   return !isLink
 }
-


### PR DESCRIPTION
### Context

- fixes #1902 

### Changes
The callback url will be stored in session storage until it is used by the login flow.
If the callback url provided does not exits the flow will redirect to '/'.
The redirect now works if the user is already logged in.

NONE: 
The callback url will not be retired as a param in the URL if the user navigate to "forgot password".