### PR TITLE
fix(build&publish): correct API base URLs in build-publish workflow

### DIFF
--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -75,13 +75,13 @@ jobs:
           - name: test-boutique-frontend
             identifier: 'boutique:frontend'
             path: packages/boutique/frontend
-            api_base_url: 'https://api.boutique.interledger-test.dev'
+            api_base_url: 'https://api-boutique.interledger-test.dev'
             currency: 'USD'
             theme: dark
           - name: test-boutique-frontend-jopacc
             identifier: 'boutique:frontend'
             path: packages/boutique/frontend
-            api_base_url: 'https://api.boutique.jopacc.openpayments.directory'
+            api_base_url: 'https://api-boutique.jopacc.openpayments.directory'
             currency: 'JOD'
             theme: light
           - name: test-boutique-backend

--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -75,7 +75,7 @@ jobs:
           - name: test-boutique-frontend
             identifier: 'boutique:frontend'
             path: packages/boutique/frontend
-            api_base_url: 'https://api-boutique.interledger-test.dev'
+            api_base_url: 'https://api.boutique.interledger-test.dev'
             currency: 'USD'
             theme: dark
           - name: test-boutique-frontend-jopacc


### PR DESCRIPTION
This pr fixes the url used for api_base_url in the jopacc-specific boutique frontend image
