### PR TITLE
feat: Add second party WA, and refund option

### DIFF
--- a/packages/wallet/frontend/src/components/dialogs/TransactionDetailsDialog.tsx
+++ b/packages/wallet/frontend/src/components/dialogs/TransactionDetailsDialog.tsx
@@ -203,7 +203,7 @@ export const TransactionDetailsDialog = ({
                         }}
                       >
                         {transaction.type === 'INCOMING'
-                          ? 'Send Back'
+                          ? 'Refund'
                           : 'Send Again'}
                       </Button>
                     </div>

--- a/packages/wallet/frontend/src/components/dialogs/TransactionDetailsDialog.tsx
+++ b/packages/wallet/frontend/src/components/dialogs/TransactionDetailsDialog.tsx
@@ -19,6 +19,9 @@ import { cx } from 'class-variance-authority'
 import { Badge, getStatusBadgeIntent } from '@/ui/Badge'
 import { Card } from '../icons/CardButtons'
 import { FEATURES_ENABLED } from '@/utils/constants'
+import { Button } from '@/ui/Button'
+import { useRouter } from 'next/router'
+import { useRefundContext } from '@/lib/context/refund'
 
 type TransactionDetailsDialogProps = Pick<DialogProps, 'onClose'> & {
   transaction: TransactionListResponse
@@ -30,6 +33,9 @@ export const TransactionDetailsDialog = ({
   transaction,
   isCardWalletAddress
 }: TransactionDetailsDialogProps) => {
+  const router = useRouter()
+  const { setReceiverWalletAddress } = useRefundContext()
+
   return (
     <Transition show={true} as={Fragment} appear={true}>
       <Dialog as="div" className="relative z-10" onClose={onClose}>
@@ -76,6 +82,16 @@ export const TransactionDetailsDialog = ({
                           : 'Receiver: '}
                       </span>
                       <span>{transaction.secondParty}</span>
+                    </div>
+                  ) : null}
+                  {transaction.secondPartyWA ? (
+                    <div>
+                      <span className="font-bold">
+                        {transaction.type === 'INCOMING'
+                          ? 'Sender Wallet Address: '
+                          : 'Receiver Wallet Address: '}
+                      </span>
+                      <span>{transaction.secondPartyWA}</span>
                     </div>
                   ) : null}
                   <div>
@@ -139,13 +155,13 @@ export const TransactionDetailsDialog = ({
                   ) : null}
                   <div>
                     <span className="font-bold">
-                      Payment Pointer Public Name:{' '}
+                      Wallet Address Public Name:{' '}
                     </span>
                     <span>{transaction.walletAddressPublicName}</span>
                   </div>
                   {transaction.walletAddressUrl ? (
                     <div>
-                      <span className="font-bold">Payment Pointer URL: </span>
+                      <span className="font-bold">Your Wallet Address: </span>
                       <span>
                         {replaceCardWalletAddressDomain(
                           transaction.walletAddressUrl,
@@ -171,6 +187,27 @@ export const TransactionDetailsDialog = ({
                       />
                     </span>
                   </div>
+                  {transaction.secondPartyWA ? (
+                    <div className="flex justify-center">
+                      <Button
+                        intent="outline"
+                        aria-label="send redirect"
+                        onClick={() => {
+                          setReceiverWalletAddress(
+                            transaction.secondPartyWA
+                              ? transaction.secondPartyWA
+                              : ''
+                          )
+                          router.push('/send')
+                          onClose()
+                        }}
+                      >
+                        {transaction.type === 'INCOMING'
+                          ? 'Send Back'
+                          : 'Send Again'}
+                      </Button>
+                    </div>
+                  ) : null}
                 </div>
               </DialogPanel>
             </TransitionChild>

--- a/packages/wallet/frontend/src/components/providers/RefundProvider.tsx
+++ b/packages/wallet/frontend/src/components/providers/RefundProvider.tsx
@@ -1,0 +1,21 @@
+import { RefundContext } from '@/lib/context/refund'
+import { ReactNode, useState } from 'react'
+
+type RefundProviderProps = {
+  children: ReactNode
+}
+
+export const RefundProvider = ({ children }: RefundProviderProps) => {
+  const [receiverWalletAddress, setReceiverWalletAddress] = useState('')
+
+  return (
+    <RefundContext.Provider
+      value={{
+        receiverWalletAddress,
+        setReceiverWalletAddress
+      }}
+    >
+      {children}
+    </RefundContext.Provider>
+  )
+}

--- a/packages/wallet/frontend/src/components/providers/index.tsx
+++ b/packages/wallet/frontend/src/components/providers/index.tsx
@@ -3,6 +3,7 @@ import { DialogProvider } from './DialogProvider'
 import { OnboardingProvider } from './OnboardingProvider'
 import { PasswordProvider } from './PasswordProvider'
 import { MenuProvider } from './MenuProvider'
+import { RefundProvider } from './RefundProvider'
 
 type AppProviderProps = {
   children: ReactNode
@@ -12,9 +13,11 @@ export const AppProvider = ({ children }: AppProviderProps) => {
   return (
     <MenuProvider>
       <OnboardingProvider>
-        <PasswordProvider>
-          <DialogProvider>{children}</DialogProvider>
-        </PasswordProvider>
+        <RefundProvider>
+          <PasswordProvider>
+            <DialogProvider>{children}</DialogProvider>
+          </PasswordProvider>
+        </RefundProvider>
       </OnboardingProvider>
     </MenuProvider>
   )

--- a/packages/wallet/frontend/src/lib/context/refund.ts
+++ b/packages/wallet/frontend/src/lib/context/refund.ts
@@ -1,0 +1,20 @@
+import { createContext, useContext } from 'react'
+
+type RefundContextProps = {
+  receiverWalletAddress: string
+  setReceiverWalletAddress: (receiverWalletAddress: string) => void
+}
+
+export const RefundContext = createContext<RefundContextProps | null>(null)
+
+export const useRefundContext = () => {
+  const refundContext = useContext(RefundContext)
+
+  if (!refundContext) {
+    throw new Error(
+      '"useRefundContext" is used outside the RefundContextProvider.'
+    )
+  }
+
+  return refundContext
+}

--- a/packages/wallet/frontend/src/pages/send.tsx
+++ b/packages/wallet/frontend/src/pages/send.tsx
@@ -38,6 +38,7 @@ import { ExchangeRate } from '@/components/ExchangeRate'
 import { useSnapshot } from 'valtio'
 import { balanceState } from '@/lib/balance'
 import { AssetOP } from '@wallet/shared'
+import { useRefundContext } from '@/lib/context/refund'
 
 type SendProps = InferGetServerSidePropsType<typeof getServerSideProps>
 
@@ -59,6 +60,7 @@ const SendPage: NextPageWithLayout<SendProps> = ({ accounts }) => {
   const [incomingPaymentAmount, setIncomingPaymentAmount] = useState(0)
   const [readOnlyNotes, setReadOnlyNotes] = useState(false)
   const { accountsSnapshot } = useSnapshot(balanceState)
+  const { receiverWalletAddress, setReceiverWalletAddress } = useRefundContext()
   const imageName =
     THEME === 'dark' ? '/bird-envelope-dark.webp' : '/bird-envelope-light.webp'
 
@@ -365,6 +367,9 @@ const SendPage: NextPageWithLayout<SendProps> = ({ accounts }) => {
             name="receiver"
             control={sendForm.control}
             render={({ field: { value } }) => {
+              value =
+                receiverWalletAddress !== '' ? receiverWalletAddress : value
+              setReceiverWalletAddress('')
               return (
                 <DebouncedInput
                   required


### PR DESCRIPTION
<!--
If the PR is related to an open issue(s) please provide a list of them.

Example:
    - closes (or fixes) #<issue number>
    - closes (or fixes) #<issue number>
-->

### Context

- fixes #1929 

<!--
Short description of what has changed
-->

### Changes

When second party Wallet Address is available, show it on Transaction Details popup.
Also add a button to redirect to send page, with the second party WA already pre-populated. This is a kind of a refund when you receive money, or it is a Send Again functionality when you sent someone money and you want to send again.
