### PR TITLE
feat: Reload transaction page when money is received

### DIFF
--- a/packages/wallet/frontend/src/lib/hooks/useToast.ts
+++ b/packages/wallet/frontend/src/lib/hooks/useToast.ts
@@ -151,6 +151,12 @@ export function toast({ ...props }: Toast) {
       open: true,
       onOpenChange: (open) => {
         if (!open) dismiss()
+        if (
+          props.title === 'Received Money' &&
+          window.location.href.indexOf('/transactions') !== -1
+        ) {
+          window.location.reload()
+        }
       }
     }
   })

--- a/packages/wallet/frontend/src/pages/_app.tsx
+++ b/packages/wallet/frontend/src/pages/_app.tsx
@@ -57,6 +57,7 @@ export default function App({ Component, pageProps }: AppPropsWithLayout) {
             into account {account.name}.
           </p>
         ),
+        title: 'Received Money',
         variant: 'success'
       })
       updateBalance(


### PR DESCRIPTION
<!--
If the PR is related to an open issue(s) please provide a list of them.

Example:
    - closes (or fixes) #<issue number>
    - closes (or fixes) #<issue number>
-->

### Context

- fixes #1907 

<!--
Short description of what has changed
-->

### Changes

When you are on transaction page, and toast notification appears with you receiving money, reload the transaction page, to see the Completed status of the transaction.
