### PR TITLE
feat(stripe): stripe controller uses gatehubWalletId

### DIFF
--- a/packages/wallet/backend/src/gatehub/service.ts
+++ b/packages/wallet/backend/src/gatehub/service.ts
@@ -1,7 +1,7 @@
 import { GateHubClient } from '@/gatehub/client'
 import { IFRAME_TYPE } from '@wallet/shared/src'
 import { User } from '@/user/model'
-import { NotFound } from '@shared/backend'
+import { BadRequest, NotFound } from '@shared/backend'
 import {
   IAddUserToGatewayResponse,
   ICardTransactionWebhookData,
@@ -419,5 +419,23 @@ export class GateHubService {
 
   private async updateUserFlag(userId: string, changes: Partial<User>) {
     await User.query().findById(userId).patch(changes)
+  }
+
+  public async getGateHubWalletAddress(walletAddress: WalletAddress) {
+    const account = await Account.query()
+      .findById(walletAddress.accountId)
+      .withGraphFetched('user')
+
+    if (!account?.gateHubWalletId || !account.user?.gateHubUserId) {
+      throw new BadRequest(
+        'No account associated to the provided payment pointer'
+      )
+    }
+
+    return {
+      userId: account.userId,
+      gateHubWalletId: account.gateHubWalletId,
+      gateHubUserId: account.user.gateHubUserId
+    }
   }
 }

--- a/packages/wallet/backend/src/gatehub/service.ts
+++ b/packages/wallet/backend/src/gatehub/service.ts
@@ -1,7 +1,7 @@
 import { GateHubClient } from '@/gatehub/client'
 import { IFRAME_TYPE } from '@wallet/shared/src'
 import { User } from '@/user/model'
-import { BadRequest, NotFound } from '@shared/backend'
+import { NotFound } from '@shared/backend'
 import {
   IAddUserToGatewayResponse,
   ICardTransactionWebhookData,

--- a/packages/wallet/backend/src/gatehub/service.ts
+++ b/packages/wallet/backend/src/gatehub/service.ts
@@ -420,22 +420,4 @@ export class GateHubService {
   private async updateUserFlag(userId: string, changes: Partial<User>) {
     await User.query().findById(userId).patch(changes)
   }
-
-  public async getGateHubWalletAddress(walletAddress: WalletAddress) {
-    const account = await Account.query()
-      .findById(walletAddress.accountId)
-      .withGraphFetched('user')
-
-    if (!account?.gateHubWalletId || !account.user?.gateHubUserId) {
-      throw new BadRequest(
-        'No account associated to the provided payment pointer'
-      )
-    }
-
-    return {
-      userId: account.userId,
-      gateHubWalletId: account.gateHubWalletId,
-      gateHubUserId: account.user.gateHubUserId
-    }
-  }
 }

--- a/packages/wallet/backend/src/rafiki/service.ts
+++ b/packages/wallet/backend/src/rafiki/service.ts
@@ -1,18 +1,16 @@
 import { Env } from '@/config/env'
-import { WalletAddress } from '@/walletAddress/model'
-import { ISecondParty, TransactionService } from '@/transaction/service'
-import { Logger } from 'winston'
-import { RafikiClient } from './rafiki-client'
-import { SocketService } from '@/socket/service'
-import { NodeCacheInstance } from '@/utils/helpers'
-import { WalletAddressService } from '@/walletAddress/service'
-import { Account } from '@/account/model'
-import MessageType from '@/socket/messageType'
-import { BadRequest } from '@shared/backend'
 import { GateHubClient } from '@/gatehub/client'
 import { TransactionTypeEnum } from '@/gatehub/consts'
+import MessageType from '@/socket/messageType'
+import { SocketService } from '@/socket/service'
+import { ISecondParty, TransactionService } from '@/transaction/service'
+import { NodeCacheInstance } from '@/utils/helpers'
+import { WalletAddressService } from '@/walletAddress/service'
+import { BadRequest } from '@shared/backend'
+import { Logger } from 'winston'
+import { AccountService } from '../account/service'
+import { RafikiClient } from './rafiki-client'
 import { WebhookType } from './validation'
-import { GateHubService } from '../gatehub/service'
 
 export enum EventType {
   IncomingPaymentCreated = 'incoming_payment.created',
@@ -79,12 +77,12 @@ export class RafikiService implements IRafikiService {
   constructor(
     private socketService: SocketService,
     private gateHubClient: GateHubClient,
-    private gateHubService: GateHubService,
     private env: Env,
     private logger: Logger,
     private rafikiClient: RafikiClient,
     private transactionService: TransactionService,
-    private walletAddressService: WalletAddressService
+    private walletAddressService: WalletAddressService,
+    private accountService: AccountService
   ) {}
 
   public async onWebHook(wh: WebhookType): Promise<void> {
@@ -166,7 +164,7 @@ export class RafikiService implements IRafikiService {
     const amount = this.getAmountFromWebHook(wh)
 
     const { gateHubWalletId: receiverWallet, userId } =
-      await this.gateHubService.getGateHubWalletAddress(walletAddress)
+      await this.accountService.getGateHubWalletAddress(walletAddress)
 
     if (!this.validateAmount(amount, wh.type)) {
       //* Only in case the expired incoming payment has no money received will it be set as expired.
@@ -233,7 +231,7 @@ export class RafikiService implements IRafikiService {
     const amount = this.getAmountFromWebHook(wh)
 
     const { gateHubWalletId, gateHubUserId } =
-      await this.gateHubService.getGateHubWalletAddress(walletAddress)
+      await this.accountService.getGateHubWalletAddress(walletAddress)
 
     if (!this.validateAmount(amount, wh.type)) {
       return
@@ -278,7 +276,7 @@ export class RafikiService implements IRafikiService {
       gateHubWalletId: sendingWallet,
       userId,
       gateHubUserId
-    } = await this.gateHubService.getGateHubWalletAddress(walletAddress)
+    } = await this.accountService.getGateHubWalletAddress(walletAddress)
 
     if (!this.validateAmount(debitAmount, wh.type)) {
       return
@@ -338,7 +336,7 @@ export class RafikiService implements IRafikiService {
     const sentAmount = this.parseAmount(wh.data.sentAmount as AmountJSON)
 
     const { gateHubWalletId: sendingWallet } =
-      await this.gateHubService.getGateHubWalletAddress(walletAddress)
+      await this.accountService.getGateHubWalletAddress(walletAddress)
 
     await this.transactionService.updateTransaction(
       { paymentId: wh.data.id },

--- a/packages/wallet/backend/src/stripe-integration/service.ts
+++ b/packages/wallet/backend/src/stripe-integration/service.ts
@@ -5,7 +5,7 @@ import { Env } from '../config/env'
 import { TransactionTypeEnum } from '../gatehub/consts'
 import { StripeWebhookType } from './validation'
 import { WalletAddressService } from '../walletAddress/service'
-import { GateHubService } from '../gatehub/service'
+import { AccountService } from '../account/service'
 
 export enum EventType {
   payment_intent_canceled = 'payment_intent.canceled',
@@ -23,7 +23,7 @@ export class StripeService implements IStripeService {
     private logger: Logger,
     private gateHubClient: GateHubClient,
     private walletAddressService: WalletAddressService,
-    private gateHubService: GateHubService
+    private accountService: AccountService
   ) {}
 
   public async onWebHook(wh: StripeWebhookType): Promise<void> {
@@ -50,15 +50,15 @@ export class StripeService implements IStripeService {
     const amount: number = paymentIntent.amount
 
     try {
-      const walletAddress = await this.walletAddressService.getByUrl(
-        receiving_address
-      )
+      const walletAddress =
+        await this.walletAddressService.getByUrl(receiving_address)
 
       if (!walletAddress) {
         throw new BadRequest('Wallet address not found')
       }
 
-      const { gateHubWalletId } = await this.gateHubService.getGateHubWalletAddress(walletAddress)
+      const { gateHubWalletId } =
+        await this.accountService.getGateHubWalletAddress(walletAddress)
 
       await this.gateHubClient.createTransaction({
         amount,

--- a/packages/wallet/backend/tests/stripe-integration/controller.test.ts
+++ b/packages/wallet/backend/tests/stripe-integration/controller.test.ts
@@ -44,20 +44,22 @@ describe('Stripe Controller', () => {
     res = createResponse()
     req = createRequest()
     req.headers['stripe-signature'] = 'mock-signature'
-    req.body = Buffer.from(JSON.stringify({
-      id: 'webhookId123',
-      type: EventType.payment_intent_succeeded,
-      data: {
-        object: {
-          id: 'pi_123456',
-          amount: 1000,
-          currency: 'usd',
-          metadata: {
-            receiving_address: 'wallet_address_123'
+    req.body = Buffer.from(
+      JSON.stringify({
+        id: 'webhookId123',
+        type: EventType.payment_intent_succeeded,
+        data: {
+          object: {
+            id: 'pi_123456',
+            amount: 1000,
+            currency: 'usd',
+            metadata: {
+              receiving_address: 'wallet_address_123'
+            }
           }
         }
-      }
-    }))
+      })
+    )
 
     await applyMiddleware(withSession, req, res)
   }
@@ -66,7 +68,9 @@ describe('Stripe Controller', () => {
     const stripeControllerDepsMocked = {
       stripeService: {
         onWebHook: isFailure
-          ? jest.fn().mockRejectedValueOnce(new BadRequest('Test bad request error'))
+          ? jest
+              .fn()
+              .mockRejectedValueOnce(new BadRequest('Test bad request error'))
           : jest.fn().mockResolvedValue(undefined)
       },
       logger: {
@@ -191,20 +195,22 @@ describe('Stripe Controller', () => {
       mockConstructEvent.mockReturnValue({})
 
       // unknown event type
-      req.body = Buffer.from(JSON.stringify({
-        id: 'webhookId123',
-        type: 'unknown_event_type',
-        data: {
-          object: {
-            id: 'pi_123456',
-            amount: 1000,
-            currency: 'usd',
-            metadata: {
-              receiving_address: 'wallet_address_123'
+      req.body = Buffer.from(
+        JSON.stringify({
+          id: 'webhookId123',
+          type: 'unknown_event_type',
+          data: {
+            object: {
+              id: 'pi_123456',
+              amount: 1000,
+              currency: 'usd',
+              metadata: {
+                receiving_address: 'wallet_address_123'
+              }
             }
           }
-        }
-      }))
+        })
+      )
 
       await stripeController.onWebHook(req, res, (err) => {
         next()
@@ -225,18 +231,20 @@ describe('Stripe Controller', () => {
       mockConstructEvent.mockReturnValue({})
 
       // (missing receiving_address)
-      req.body = Buffer.from(JSON.stringify({
-        id: 'webhookId123',
-        type: EventType.payment_intent_succeeded,
-        data: {
-          object: {
-            id: 'pi_123456',
-            amount: 1000,
-            currency: 'usd',
-            metadata: {}
+      req.body = Buffer.from(
+        JSON.stringify({
+          id: 'webhookId123',
+          type: EventType.payment_intent_succeeded,
+          data: {
+            object: {
+              id: 'pi_123456',
+              amount: 1000,
+              currency: 'usd',
+              metadata: {}
+            }
           }
-        }
-      }))
+        })
+      )
 
       await stripeController.onWebHook(req, res, (err) => {
         next()

--- a/packages/wallet/backend/tests/stripe-integration/service.test.ts
+++ b/packages/wallet/backend/tests/stripe-integration/service.test.ts
@@ -84,16 +84,8 @@ describe('Stripe Service', (): void => {
       mockGateHubClient as unknown as GateHubClient
     )
     Reflect.set(stripeService, 'logger', mockLogger)
-    Reflect.set(
-      stripeService,
-      'walletAddressService',
-      mockWalletAddressService
-    )
-    Reflect.set(
-      stripeService,
-      'accountService',
-      mockAccountService
-    )
+    Reflect.set(stripeService, 'walletAddressService', mockWalletAddressService)
+    Reflect.set(stripeService, 'accountService', mockAccountService)
 
     // Mock vault UUID lookup
     mockGateHubClient.getVaultUuid.mockReturnValue('vault-uuid-123')


### PR DESCRIPTION
moved `getGateHubWalletAddress` into gatehubService as it is now used both in rafikiService and in StripeService.

Stripe service now uses the gatehub transaction method with proper gatehubWalletId