### PR TITLE
feat(stripe): stripe payments now create a transaction in wallet

### DIFF
--- a/packages/wallet/backend/migrations/20250425115946_add_transaction_type.js
+++ b/packages/wallet/backend/migrations/20250425115946_add_transaction_type.js
@@ -1,0 +1,46 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema
+    .table('transactions', (table) => {
+      table.enum('source', ['Interledger', 'Stripe', 'Card'])
+    })
+    .then(() => {
+      return knex('transactions')
+        .update({ source: 'Card' })
+        .where({ isCard: true })
+    })
+    .then(() => {
+      return knex('transactions')
+        .update({ source: 'Interledger' })
+        .whereNull('source')
+    })
+    .then(() => {
+      return knex.schema.table('transactions', (table) => {
+        table.dropColumn('isCard')
+      })
+    })
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema
+    .table('transactions', (table) => {
+      table.boolean('isCard').defaultTo(false)
+    })
+    .then(() => {
+      return knex('transactions')
+        .update({ isCard: true })
+        .where({ source: 'Card' })
+    })
+    .then(() => {
+      return knex.schema.table('transactions', (table) => {
+        table.dropColumn('source')
+      })
+    })
+}

--- a/packages/wallet/backend/src/gatehub/service.ts
+++ b/packages/wallet/backend/src/gatehub/service.ts
@@ -166,7 +166,7 @@ export class GateHubService {
       type: 'OUTGOING',
       status: 'COMPLETED',
       description: '',
-      isCard: true
+      source: 'Card'
     })
   }
 

--- a/packages/wallet/backend/src/stripe-integration/service.ts
+++ b/packages/wallet/backend/src/stripe-integration/service.ts
@@ -25,7 +25,7 @@ export class StripeService implements IStripeService {
     private logger: Logger,
     private gateHubClient: GateHubClient,
     private walletAddressService: WalletAddressService,
-    private accountService: AccountService,
+    private accountService: AccountService
   ) {}
 
   public async onWebHook(wh: StripeWebhookType): Promise<void> {

--- a/packages/wallet/backend/src/transaction/model.ts
+++ b/packages/wallet/backend/src/transaction/model.ts
@@ -5,6 +5,7 @@ import { BaseModel } from '@shared/backend'
 import { TransactionResponse } from '@wallet/shared'
 
 export type TransactionType = 'INCOMING' | 'OUTGOING'
+export type TransactionSource = 'Interledger' | 'Stripe' | 'Card'
 export type TransactionExtended = Transaction & {
   walletAddressUrl: WalletAddress['url']
   accountName: Account['name']
@@ -31,7 +32,7 @@ export class Transaction
   assetCode!: string
   value!: bigint | null
   walletAddress!: WalletAddress
-  isCard?: boolean
+  source!: TransactionSource
   txAmount?: bigint
   txCurrency?: string
   conversionRate?: string

--- a/packages/wallet/backend/src/transaction/service.ts
+++ b/packages/wallet/backend/src/transaction/service.ts
@@ -1,4 +1,4 @@
-import { Transaction } from './model'
+import { Transaction, TransactionSource } from './model'
 import { OrderByDirection, Page, PartialModelObject } from 'objection'
 import { AccountService } from '@/account/service'
 import { Logger } from 'winston'
@@ -122,7 +122,7 @@ export class TransactionService implements ITransactionService {
     }
 
     const latestTransaction: Transaction | undefined = await Transaction.query()
-      .findOne({ accountId: account.id, isCard: true })
+      .findOne({ accountId: account.id, source: 'Card' })
       .orderBy('createdAt', 'DESC')
 
     const walletAddress = await WalletAddress.query().findOne({
@@ -171,7 +171,7 @@ export class TransactionService implements ITransactionService {
           type: 'OUTGOING',
           status: 'COMPLETED',
           description: '',
-          isCard: true,
+          source: 'Card' as TransactionSource,
           secondParty: transaction.merchantName,
           txAmount: transaction.transactionAmount
             ? transformBalance(Number(transaction.transactionAmount), 2)
@@ -229,7 +229,8 @@ export class TransactionService implements ITransactionService {
       value: amount.value,
       type: 'INCOMING',
       status: 'PENDING',
-      description: params.metadata?.description
+      description: params.metadata?.description,
+      source: 'Interledger'
     })
   }
 
@@ -256,7 +257,8 @@ export class TransactionService implements ITransactionService {
       status: 'PENDING',
       description: params.metadata?.description,
       secondParty: secondParty?.names,
-      secondPartyWA: secondParty?.walletAddresses
+      secondPartyWA: secondParty?.walletAddresses,
+      source: 'Interledger'
     })
   }
 }


### PR DESCRIPTION
This PR adds transaction entries in wallet's database for stripe payments.

Note that there are also changes to our Transaction Model, by removing the `isCard` property and adding a new 
`source` property, which can take the following values:

- Card -> for Interledger Card transactions
- Interledger -> for rafiki transactions
- Stripe -> for transactions that originate from stripe (Interledger-pay will supports stripe payments)

Migration is also included to handle this schema update.



