### PR TITLE
fix(TerminateCardDialog): replace deprecated code with updated implem…

### DIFF
--- a/packages/wallet/frontend/src/components/dialogs/TerminateCardDialog.tsx
+++ b/packages/wallet/frontend/src/components/dialogs/TerminateCardDialog.tsx
@@ -1,5 +1,5 @@
 import type { DialogProps } from '@/lib/types/dialog'
-import { Dialog, Transition, TransitionChild } from '@headlessui/react'
+import { Dialog, DialogPanel, Transition, TransitionChild, DialogTitle } from '@headlessui/react'
 import { Fragment } from 'react'
 import { Button } from '@/ui/Button'
 import { useDialog } from '@/lib/hooks/useDialog'
@@ -32,7 +32,7 @@ export const TerminateCardDialog = ({
   })
 
   return (
-    <Transition.Root show={true} as={Fragment} appear={true}>
+    <Transition show={true} as={Fragment} appear={true}>
       <Dialog as="div" className="relative z-10" onClose={onClose}>
         <TransitionChild
           as={Fragment}
@@ -56,13 +56,13 @@ export const TerminateCardDialog = ({
               leaveFrom="opacity-100 translate-y-0"
               leaveTo="opacity-0 translate-y-4"
             >
-              <Dialog.Panel className="relative w-full max-w-xl space-y-4 rounded-lg bg-white p-2 shadow-xl dark:bg-purple sm:p-8">
-                <Dialog.Title
+              <DialogPanel className="relative w-full max-w-xl space-y-4 rounded-lg bg-white p-2 shadow-xl dark:bg-purple sm:p-8">
+                <DialogTitle
                   as="h3"
                   className="text-center text-2xl font-bold"
                 >
                   Terminate Card
-                </Dialog.Title>
+                </DialogTitle>
                 <div className="px-4">
                   <Form
                     form={terminateCardForm}
@@ -133,11 +133,11 @@ export const TerminateCardDialog = ({
                     </div>
                   </Form>
                 </div>
-              </Dialog.Panel>
+              </DialogPanel>
             </TransitionChild>
           </div>
         </div>
       </Dialog>
-    </Transition.Root>
+    </Transition>
   )
 }

--- a/packages/wallet/frontend/src/components/dialogs/TerminateCardDialog.tsx
+++ b/packages/wallet/frontend/src/components/dialogs/TerminateCardDialog.tsx
@@ -1,5 +1,5 @@
 import type { DialogProps } from '@/lib/types/dialog'
-import { Dialog, Transition } from '@headlessui/react'
+import { Dialog, Transition, TransitionChild } from '@headlessui/react'
 import { Fragment } from 'react'
 import { Button } from '@/ui/Button'
 import { useDialog } from '@/lib/hooks/useDialog'
@@ -34,7 +34,7 @@ export const TerminateCardDialog = ({
   return (
     <Transition.Root show={true} as={Fragment} appear={true}>
       <Dialog as="div" className="relative z-10" onClose={onClose}>
-        <Transition.Child
+        <TransitionChild
           as={Fragment}
           enter="ease-out duration-300"
           enterFrom="opacity-0"
@@ -44,10 +44,10 @@ export const TerminateCardDialog = ({
           leaveTo="opacity-0"
         >
           <div className="fixed inset-0 bg-green-modal/75 transition-opacity dark:bg-black/75" />
-        </Transition.Child>
+        </TransitionChild>
         <div className="fixed inset-0 z-10 overflow-y-auto">
           <div className="flex min-h-full items-center justify-center p-4">
-            <Transition.Child
+            <TransitionChild
               as={Fragment}
               enter="ease-out duration-300"
               enterFrom="opacity-0 translate-y-4"
@@ -134,7 +134,7 @@ export const TerminateCardDialog = ({
                   </Form>
                 </div>
               </Dialog.Panel>
-            </Transition.Child>
+            </TransitionChild>
           </div>
         </div>
       </Dialog>


### PR DESCRIPTION
🧩 Summary

This PR resolves the deprecation warning in TerminateCardDialog by updating the usage of the Transition.Child component from HeadlessUI to the latest standalone TransitionChild component introduced in HeadlessUI v2.

✅ Changes Made

Added import for TransitionChild from @headlessui/react

Replaced both instances of <Transition.Child> with <TransitionChild>

Verified that the modal animation and transitions remain fully functional

🔍 Rationale

HeadlessUI v2 deprecated the nested component pattern (Transition.Child) in favor of standalone components (TransitionChild, TransitionRoot, etc.) for:

Better tree-shaking support

Cleaner import structure

Improved performance and readability

This update ensures compatibility with the latest version of HeadlessUI while maintaining identical UI behavior.

🧪 Testing

Verified that the Terminate Card dialog opens, transitions, and closes correctly.

Confirmed that no deprecation warnings are logged in the console.

Functionality of the form, toast notifications, and dialog closure remains intact.

📁 File Updated
src/components/TerminateCardDialog.tsx

🧾 Example of Updated Import
import { Dialog, Transition, TransitionChild } from '@headlessui/react'


🧠 Additional Context

This refactor aligns the codebase with the modern HeadlessUI component architecture and contributes toward keeping the project dependencies up-to-date and maintainable.

🔗 Related Issue

Closes #2032