### PR TITLE
fix(ci): renovate now consideres node 20

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,16 +3,24 @@
   "branchConcurrentLimit": 0,
   "branchPrefix": "renovate-",
   "enabled": true,
-  "extends": ["config:base"],
+  "extends": ["config:base", "security:all"],
   "packageRules": [
     {
       "matchPackageNames": ["@types/node", "node"],
-      "allowedVersions": "<=18.14.0"
+      "allowedVersions": ">=20.12.0"
+    },
+    {
+      "matchDatasources": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "rangeStrategy": "auto"
     }
   ],
   "prConcurrentLimit": 10,
   "prCreation": "not-pending",
   "prHourlyLimit": 2,
   "rangeStrategy": "bump",
-  "rebaseWhen": "conflicted"
+  "rebaseWhen": "conflicted",
+  "vulnerabilityAlerts": {
+    "enabled": true
+  }
 }


### PR DESCRIPTION
This pull request updates the `renovate.json` configuration to improve dependency management and security. The most notable changes are the adoption of stricter security settings, updating Node.js version constraints, and refining how Renovate handles updates.

"matchDatasources": ["npm"] — This rule applies only to npm packages (the JavaScript/Node.js package manager). Renovate supports multiple datasources like Docker, PyPI, etc., so this ensures we're only configuring npm behavior.

"matchUpdateTypes": ["minor", "patch"] — This targets minor and patch version updates
