### PR TITLE
fix: enforce subject and access ownership checks for grants

### DIFF
--- a/packages/wallet/backend/src/grant/service.ts
+++ b/packages/wallet/backend/src/grant/service.ts
@@ -38,9 +38,23 @@ export class GrantService implements IGrantService {
       nonce
     )
 
-    const url = grant.access.find(({ identifier }) => identifier)?.identifier
+    const accessIdentifier = grant.access.find(
+      ({ identifier }) => identifier
+    )?.identifier
+    const subjectIdentifier = grant.subject?.sub_ids?.[0]?.id
+    const identifiers = [accessIdentifier, subjectIdentifier].filter(
+      (identifier): identifier is string => !!identifier
+    )
+    const url = accessIdentifier ?? subjectIdentifier
+    const ownershipChecks = await Promise.all(
+      identifiers.map((identifier) =>
+        this.walletAddressService.belongsToUser(userId, identifier)
+      )
+    )
+    const belongsToUser =
+      identifiers.length > 0 && ownershipChecks.every((belongs) => belongs)
 
-    if (!url || !(await this.walletAddressService.belongsToUser(userId, url))) {
+    if (!url || !belongsToUser) {
       // reject the grant if the user does not have access
       await this.rafikiAuthService.setInteractionResponse(
         interactionId,

--- a/packages/wallet/backend/src/grant/service.ts
+++ b/packages/wallet/backend/src/grant/service.ts
@@ -45,16 +45,15 @@ export class GrantService implements IGrantService {
     const identifiers = [accessIdentifier, subjectIdentifier].filter(
       (identifier): identifier is string => !!identifier
     )
-    const url = accessIdentifier ?? subjectIdentifier
     const ownershipChecks = await Promise.all(
       identifiers.map((identifier) =>
         this.walletAddressService.belongsToUser(userId, identifier)
       )
     )
     const belongsToUser =
-      identifiers.length > 0 && ownershipChecks.every((belongs) => belongs)
+      identifiers.length && ownershipChecks.every((belongs) => belongs)
 
-    if (!url || !belongsToUser) {
+    if (!belongsToUser) {
       // reject the grant if the user does not have access
       await this.rafikiAuthService.setInteractionResponse(
         interactionId,


### PR DESCRIPTION
### Context

This continues the work started in [https://github.com/interledger/testnet/issues/2172](https://github.com/interledger/testnet/issues/2172)


The change is aligned with:

- Rafiki v2.1.0-beta: [https://github.com/interledger/rafiki/releases/tag/v2.1.0-beta](https://github.com/interledger/rafiki/releases/tag/v2.1.0-beta)

- Open Payments spec update for subject identifiers: [here](https://github.com/interledger/rafiki/blob/8b1ec9c6f89b5746bd3225bddf31a204b3431c5d/packages/auth/src/openapi/specs/id-provider.yaml#L136-L194)


- fixes [INT1-644](https://linear.app/interledger/issue/INT1-644/fix-op-in-test-wallet-with-new-specs)  

### Changes

- Check ownership for the access identifier when present
- Check ownership for the subject identifier when present
- Reject the interaction unless all present identifiers belong to the current user