### PR TITLE
ci: pipeline should not try to commit changelog

### DIFF
--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -145,9 +145,3 @@ jobs:
           body: ${{ steps.changelog.outputs.changes }}
           tag: ${{ github.ref_name }}
           token: ${{ github.token }}
-      - name: Commit CHANGELOG.md
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          branch: main
-          commit_message: 'docs: update CHANGELOG.md for ${{ github.ref_name }} [skip ci]'
-          file_pattern: CHANGELOG.md


### PR DESCRIPTION
This pull request makes a small change to the build and publish workflow by removing the automatic commit step for `CHANGELOG.md`. This means the changelog will no longer be automatically committed after a release is published.

- Removed the `Commit CHANGELOG.md` step from the `.github/workflows/build-publish.yaml` workflow, so `CHANGELOG.md` will not be auto-committed after a release.