### PR TITLE
fix(frontend): BACKEND_INTERNAL_URL should be read from runtime

### DIFF
--- a/packages/wallet/frontend/next.config.js
+++ b/packages/wallet/frontend/next.config.js
@@ -33,9 +33,6 @@ const nextConfig = {
   eslint: { ignoreDuringBuilds: true },
   env: {
     NEXT_PUBLIC_BACKEND_URL: process.env.NEXT_PUBLIC_BACKEND_URL,
-    // Internal URL for server-side (middleware) to reach the host backend.
-    BACKEND_INTERNAL_URL:
-      process.env.BACKEND_INTERNAL_URL || process.env.BACKEND_URL,
     NEXT_PUBLIC_OPEN_PAYMENTS_HOST: process.env.NEXT_PUBLIC_OPEN_PAYMENTS_HOST,
     NEXT_PUBLIC_AUTH_HOST: process.env.NEXT_PUBLIC_AUTH_HOST,
     NEXT_PUBLIC_THEME: process.env.NEXT_PUBLIC_THEME || 'light',

--- a/packages/wallet/frontend/src/lib/httpClient.ts
+++ b/packages/wallet/frontend/src/lib/httpClient.ts
@@ -37,7 +37,9 @@ export type ErrorResponse<T = undefined> = {
 // Use internal backend URL when running on the server (SSR/middleware)
 const isServer = typeof window === 'undefined'
 const baseUrl = isServer
-  ? process.env.BACKEND_INTERNAL_URL || 'http://localhost:3003'
+  ? process.env.BACKEND_INTERNAL_URL ||
+    process.env.BACKEND_URL ||
+    'http://localhost:3003'
   : process.env.NEXT_PUBLIC_BACKEND_URL
 
 export const httpClient = ky.extend({

--- a/packages/wallet/frontend/src/lib/httpClient.ts
+++ b/packages/wallet/frontend/src/lib/httpClient.ts
@@ -39,7 +39,7 @@ const isServer = typeof window === 'undefined'
 const baseUrl = isServer
   ? process.env.BACKEND_INTERNAL_URL ||
     process.env.BACKEND_URL ||
-    'http://localhost:3003'
+    process.env.NEXT_PUBLIC_BACKEND_URL
   : process.env.NEXT_PUBLIC_BACKEND_URL
 
 export const httpClient = ky.extend({


### PR DESCRIPTION
This pull request updates how the backend URL is determined for server-side code in the wallet frontend. The main change is to improve the fallback logic for selecting the backend URL, ensuring better reliability when environment variables are missing.

**Environment variable handling:**

* Updated the logic in `src/lib/httpClient.ts` to fall back to `BACKEND_URL` if `BACKEND_INTERNAL_URL` is not set, and finally to `'http://localhost:3003'` as a last resort. This ensures that server-side requests have a valid backend URL in more scenarios.
* Removed the `BACKEND_INTERNAL_URL` entry from the Next.js environment configuration in `next.config.js`, since the fallback logic is now handled directly in the code.