### PR TITLE
ci: migration to semantic-release

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -144,10 +144,10 @@ All commit types (`chore:`, `docs:`, `ci:`, etc.) trigger at least a patch bump 
 
 ### Releasable branches
 
-| Branch | Release type | Notes |
-|---|---|---|
-| `main` | patch / minor / major | Determined by commit types |
-| `release/vX.Y` | patch only | `feat:` or breaking commits cause the workflow to fail |
+| Branch         | Release type          | Notes                                                  |
+| -------------- | --------------------- | ------------------------------------------------------ |
+| `main`         | patch / minor / major | Determined by commit types                             |
+| `release/vX.Y` | patch only            | `feat:` or breaking commits cause the workflow to fail |
 
 ### Maintenance branches (`release/vX.Y`)
 
@@ -165,11 +165,11 @@ The workflow validates that no `feat:` or `BREAKING CHANGE` commits are present 
 
 ### Conventional Commit quick reference
 
-| Prefix | Effect |
-|---|---|
-| `fix:` | Patch bump |
-| `feat:` | Minor bump |
-| `feat!:` / `BREAKING CHANGE:` | Major bump |
+| Prefix                                                             | Effect     |
+| ------------------------------------------------------------------ | ---------- |
+| `fix:`                                                             | Patch bump |
+| `feat:`                                                            | Minor bump |
+| `feat!:` / `BREAKING CHANGE:`                                      | Major bump |
 | `chore:`, `docs:`, `ci:`, `refactor:`, `test:`, `style:`, `build:` | Patch bump |
 
 ---

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -126,6 +126,54 @@ pnpm checks && pnpm test
 
 ---
 
+## Release Process
+
+Releases are created manually via the **"Create Release"** GitHub Actions workflow (`release.yml`). There is no automatic release on merge to `main`.
+
+### How it works
+
+1. Developers write PRs with [Conventional Commit](https://www.conventionalcommits.org/) titles (enforced by `pr_title_check.yml`).
+2. When ready to release, run the **Create Release** workflow from the GitHub Actions UI and select the target branch.
+3. The workflow runs [semantic-release](https://github.com/semantic-release/semantic-release) which:
+   - Analyses commit history since the last tag
+   - Determines the version bump (`fix:` → patch, `feat:` → minor, `BREAKING CHANGE` → major)
+   - Creates a git tag (`vX.Y.Z`) and a GitHub Release with auto-generated notes
+   - Publishes Docker images to GHCR tagged `vX.Y.Z` and `latest`
+
+All commit types (`chore:`, `docs:`, `ci:`, etc.) trigger at least a patch bump — running "Create Release" always produces a new version.
+
+### Releasable branches
+
+| Branch | Release type | Notes |
+|---|---|---|
+| `main` | patch / minor / major | Determined by commit types |
+| `release/vX.Y` | patch only | `feat:` or breaking commits cause the workflow to fail |
+
+### Maintenance branches (`release/vX.Y`)
+
+A maintenance branch is used to backport fixes to an older minor version:
+
+```bash
+# Create a maintenance branch from the last patch tag of that minor
+git checkout -b release/v1.0 v1.0.44
+# Cherry-pick fix commits onto it
+git cherry-pick <sha>
+# Then run "Create Release" against release/v1.0 in the GitHub UI
+```
+
+The workflow validates that no `feat:` or `BREAKING CHANGE` commits are present before releasing.
+
+### Conventional Commit quick reference
+
+| Prefix | Effect |
+|---|---|
+| `fix:` | Patch bump |
+| `feat:` | Minor bump |
+| `feat!:` / `BREAKING CHANGE:` | Major bump |
+| `chore:`, `docs:`, `ci:`, `refactor:`, `test:`, `style:`, `build:` | Patch bump |
+
+---
+
 ## Project Structure
 
 ```
@@ -137,9 +185,14 @@ testnet/
 ├── .nvmrc                            # Node version (lts/iron)
 │
 ├── .github/workflows/
-│   ├── ci.yml                        # PR validation (checks → builds → tests)
-│   ├── deploy.yml                    # Main branch: deploy to staging/prod
+│   ├── ci.yml                        # PR validation (ESLint + Prettier)
+│   ├── build-publish.yaml            # Build validation on PRs and main
+│   ├── release.yml                   # Manual "Create Release" workflow (semantic-release)
+│   ├── deploy.yml                    # Manual deploy to staging/prod (workflow_dispatch)
+│   ├── pr_title_check.yml            # Enforces conventional commit format on PR titles
+│   ├── pr_labeler.yml                # Auto-labels PRs by changed paths
 │   └── setup/action.yml              # Reusable setup action (Node + pnpm + install)
+├── release.config.js                 # semantic-release config (supports main + release/vX.Y branches)
 │
 ├── local/                            # Local development environment
 │   ├── docker-compose.yml            # Services: Postgres, Redis, Traefik, etc.
@@ -250,10 +303,11 @@ pnpm build
    - **Test**: `pnpm test` (expect 215 pass, 1 pre-existing fail)
    - **Build** (if package changed): `pnpm {package}:backend build` or `pnpm {package}:frontend build`
 
-4. **Replicate CI locally**: The `.github/workflows/ci.yml` logic matches these commands exactly:
+4. **Replicate CI locally**: The `ci.yml` + `build-publish.yaml` logic matches these commands exactly:
    - Step 1: `pnpm checks`
    - Step 2: `pnpm {package}:frontend build` (if labeled)
    - Step 3: `pnpm {package}:backend test --detectOpenHandles --forceExit` (if build passed)
+   - Releases are **not** created automatically — use the "Create Release" workflow in GitHub Actions
 
 5. **Document discovered issues**: If you find information in this file is incomplete or incorrect, update this file in your PR.
 
@@ -265,5 +319,5 @@ pnpm build
 
 ---
 
-**Updated**: April 2026  
+**Updated**: June 2026  
 **Maintained By**: Interledger Foundation

--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -1,4 +1,4 @@
-name: Build & Publish
+name: Build
 
 on:
   pull_request:
@@ -7,8 +7,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   build:
@@ -40,108 +38,3 @@ jobs:
       - name: Run build
         run: |
           pnpm ${{ matrix.package }} build
-
-  publish:
-    runs-on: ubuntu-latest
-    needs: build
-    timeout-minutes: 15
-    if: startsWith(github.ref, 'refs/tags/v')
-    strategy:
-      matrix:
-        package:
-          - name: test-wallet-backend
-            identifier: 'wallet:backend'
-            path: packages/wallet/backend
-          - name: test-wallet-frontend
-            identifier: 'wallet:frontend'
-            path: packages/wallet/frontend
-            port: 4003
-            cookie_name: testnet.cookie
-            backend_url: https://api.wallet.interledger-test.dev
-            open_payments_host: $ilp.interledger-test.dev/
-            auth_host: https://auth.interledger-test.dev
-            gatehub_env: sandbox
-            theme: dark
-          - name: test-wallet-frontend-cards
-            identifier: 'wallet:frontend'
-            path: packages/wallet/frontend
-            port: 4003
-            cookie_name: interledgercards.cookie
-            backend_url: https://api.interledger.cards
-            open_payments_host: $ilp.dev/
-            auth_host: https://auth.interledger.cards
-            gatehub_env: production
-            theme: light
-          - name: test-boutique-frontend
-            identifier: 'boutique:frontend'
-            path: packages/boutique/frontend
-            api_base_url: 'https://api.boutique.interledger-test.dev'
-            currency: 'USD'
-            theme: light
-          - name: test-boutique-frontend-jopacc
-            identifier: 'boutique:frontend'
-            path: packages/boutique/frontend
-            api_base_url: 'https://api-boutique.jopacc.openpayments.directory'
-            currency: 'JOD'
-            theme: light
-          - name: test-boutique-backend
-            identifier: 'boutique:backend'
-            path: packages/boutique/backend
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Login to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Docker build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: ./
-          push: true
-          file: ${{ matrix.package.path }}/Dockerfile.prod
-          build-args: |
-            ${{ matrix.package.identifier == 'boutique:frontend' && format('VITE_API_BASE_URL={0}', matrix.package.api_base_url) || '' }}
-            ${{ matrix.package.identifier == 'boutique:frontend' && format('VITE_CURRENCY={0}', matrix.package.currency) || '' }}
-            ${{ matrix.package.identifier == 'boutique:frontend' && format('VITE_THEME={0}', matrix.package.theme) || '' }}
-            ${{ matrix.package.identifier == 'wallet:frontend' && format('PORT={0}', matrix.package.port) || '' }}
-            ${{ matrix.package.identifier == 'wallet:frontend' && format('COOKIE_NAME={0}', matrix.package.cookie_name) || '' }}
-            ${{ matrix.package.identifier == 'wallet:frontend' && format('NEXT_PUBLIC_BACKEND_URL={0}', matrix.package.backend_url) || '' }}
-            ${{ matrix.package.identifier == 'wallet:frontend' && format('NEXT_PUBLIC_OPEN_PAYMENTS_HOST={0}', matrix.package.open_payments_host) || '' }}
-            ${{ matrix.package.identifier == 'wallet:frontend' && format('NEXT_PUBLIC_AUTH_HOST={0}', matrix.package.auth_host) || '' }}
-            ${{ matrix.package.identifier == 'wallet:frontend' && format('NEXT_PUBLIC_GATEHUB_ENV={0}', matrix.package.gatehub_env) || '' }}
-            ${{ matrix.package.identifier == 'wallet:frontend' && format('NEXT_PUBLIC_THEME={0}', matrix.package.theme) || '' }}
-          tags: ghcr.io/${{ github.repository_owner }}/${{ matrix.package.name }}:${{ github.ref_name }},ghcr.io/${{ github.repository_owner }}/${{ matrix.package.name }}:latest
-
-  generate-release:
-    runs-on: ubuntu-latest
-    needs: publish
-    timeout-minutes: 5
-    if: startsWith(github.ref, 'refs/tags/v')
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-      - name: Update CHANGELOG
-        id: changelog
-        uses: requarks/changelog-action@v1
-        with:
-          token: ${{ github.token }}
-          tag: ${{ github.ref_name }}
-      - name: Create Release
-        uses: ncipollo/release-action@v1.20.0
-        with:
-          allowUpdates: true
-          draft: false
-          makeLatest: true
-          name: ${{ github.ref_name }}
-          body: ${{ steps.changelog.outputs.changes }}
-          tag: ${{ github.ref_name }}
-          token: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,119 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  packages: write
+
+jobs:
+  release:
+    name: Semantic Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      new_release_published: ${{ steps.semantic.outputs.new_release_published }}
+      new_release_version: ${{ steps.semantic.outputs.new_release_version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Semantic Release
+        id: semantic
+        uses: cycjimmy/semantic-release-action@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          semantic_version: 24
+          extra_plugins: |
+            @semantic-release/commit-analyzer
+            @semantic-release/release-notes-generator
+            @semantic-release/github
+
+  publish:
+    name: Publish Docker images
+    runs-on: ubuntu-latest
+    needs: release
+    if: needs.release.outputs.new_release_published == 'true'
+    timeout-minutes: 15
+    strategy:
+      matrix:
+        package:
+          - name: test-wallet-backend
+            identifier: 'wallet:backend'
+            path: packages/wallet/backend
+          - name: test-wallet-frontend
+            identifier: 'wallet:frontend'
+            path: packages/wallet/frontend
+            port: 4003
+            cookie_name: testnet.cookie
+            backend_url: https://api.wallet.interledger-test.dev
+            open_payments_host: $ilp.interledger-test.dev/
+            auth_host: https://auth.interledger-test.dev
+            gatehub_env: sandbox
+            theme: dark
+          - name: test-wallet-frontend-cards
+            identifier: 'wallet:frontend'
+            path: packages/wallet/frontend
+            port: 4003
+            cookie_name: interledgercards.cookie
+            backend_url: https://api.interledger.cards
+            open_payments_host: $ilp.dev/
+            auth_host: https://auth.interledger.cards
+            gatehub_env: production
+            theme: light
+          - name: test-boutique-frontend
+            identifier: 'boutique:frontend'
+            path: packages/boutique/frontend
+            api_base_url: 'https://api.boutique.interledger-test.dev'
+            currency: 'USD'
+            theme: light
+          - name: test-boutique-frontend-jopacc
+            identifier: 'boutique:frontend'
+            path: packages/boutique/frontend
+            api_base_url: 'https://api-boutique.jopacc.openpayments.directory'
+            currency: 'JOD'
+            theme: light
+          - name: test-boutique-backend
+            identifier: 'boutique:backend'
+            path: packages/boutique/backend
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Docker build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./
+          push: true
+          file: ${{ matrix.package.path }}/Dockerfile.prod
+          build-args: |
+            ${{ matrix.package.identifier == 'boutique:frontend' && format('VITE_API_BASE_URL={0}', matrix.package.api_base_url) || '' }}
+            ${{ matrix.package.identifier == 'boutique:frontend' && format('VITE_CURRENCY={0}', matrix.package.currency) || '' }}
+            ${{ matrix.package.identifier == 'boutique:frontend' && format('VITE_THEME={0}', matrix.package.theme) || '' }}
+            ${{ matrix.package.identifier == 'wallet:frontend' && format('PORT={0}', matrix.package.port) || '' }}
+            ${{ matrix.package.identifier == 'wallet:frontend' && format('COOKIE_NAME={0}', matrix.package.cookie_name) || '' }}
+            ${{ matrix.package.identifier == 'wallet:frontend' && format('NEXT_PUBLIC_BACKEND_URL={0}', matrix.package.backend_url) || '' }}
+            ${{ matrix.package.identifier == 'wallet:frontend' && format('NEXT_PUBLIC_OPEN_PAYMENTS_HOST={0}', matrix.package.open_payments_host) || '' }}
+            ${{ matrix.package.identifier == 'wallet:frontend' && format('NEXT_PUBLIC_AUTH_HOST={0}', matrix.package.auth_host) || '' }}
+            ${{ matrix.package.identifier == 'wallet:frontend' && format('NEXT_PUBLIC_GATEHUB_ENV={0}', matrix.package.gatehub_env) || '' }}
+            ${{ matrix.package.identifier == 'wallet:frontend' && format('NEXT_PUBLIC_THEME={0}', matrix.package.theme) || '' }}
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/${{ matrix.package.name }}:v${{ needs.release.outputs.new_release_version }}
+            ghcr.io/${{ github.repository_owner }}/${{ matrix.package.name }}:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,7 @@
-name: Release
+name: Create Release
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -12,9 +10,72 @@ permissions:
   packages: write
 
 jobs:
+  validate:
+    name: Validate branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Check branch is releasable
+        run: |
+          BRANCH="${{ github.ref_name }}"
+          if [ "$BRANCH" != "main" ] && ! echo "$BRANCH" | grep -qE '^release/v[0-9]+\.[0-9]+$'; then
+            echo "::error::Releases can only be created from 'main' or 'release/vX.Y' branches. Current branch: $BRANCH"
+            exit 1
+          fi
+          echo "Branch '$BRANCH' is valid for release."
+
+      - name: Enforce patch-only on maintenance branch
+        if: startsWith(github.ref_name, 'release/v')
+        run: |
+          BRANCH="${{ github.ref_name }}"
+          MAJOR_MINOR="${BRANCH#release/v}"
+          MAJOR="${MAJOR_MINOR%%.*}"
+          MINOR="${MAJOR_MINOR##*.}"
+
+          LAST_TAG=$(git tag -l "v${MAJOR}.${MINOR}.*" | sort -V | tail -1)
+          if [ -z "$LAST_TAG" ]; then
+            echo "No existing tags for v${MAJOR}.${MINOR}.x — this will be the first patch in this maintenance series."
+            RANGE="HEAD"
+          else
+            echo "Last tag in maintenance series: $LAST_TAG"
+            RANGE="${LAST_TAG}..HEAD"
+          fi
+
+          SUBJECTS=$(git log --format="%s" $RANGE)
+          BODIES=$(git log --format="%B" $RANGE)
+
+          ERRORS=""
+
+          if echo "$SUBJECTS" | grep -qE '^feat(\(.+\))?[!:]'; then
+            ERRORS="${ERRORS}feat commits are not allowed on maintenance branches (only patch releases permitted).\n"
+            ERRORS="${ERRORS}Offending commits:\n$(echo "$SUBJECTS" | grep -E '^feat(\(.+\))?[!:]')\n"
+          fi
+
+          if echo "$SUBJECTS" | grep -qE '^[a-z]+(\(.+\))?!:'; then
+            ERRORS="${ERRORS}Breaking change commits (! notation) are not allowed on maintenance branches.\n"
+            ERRORS="${ERRORS}Offending commits:\n$(echo "$SUBJECTS" | grep -E '^[a-z]+(\(.+\))?!:')\n"
+          fi
+
+          if echo "$BODIES" | grep -qE '^BREAKING[- ]CHANGE:'; then
+            ERRORS="${ERRORS}BREAKING CHANGE footer is not allowed on maintenance branches.\n"
+          fi
+
+          if [ -n "$ERRORS" ]; then
+            echo "::error::Maintenance branch validation failed for '$BRANCH':"
+            printf "$ERRORS"
+            exit 1
+          fi
+
+          echo "Validation passed — no major or minor commits found on '$BRANCH'."
+
   release:
     name: Semantic Release
     runs-on: ubuntu-latest
+    needs: validate
     timeout-minutes: 10
     outputs:
       new_release_published: ${{ steps.semantic.outputs.new_release_published }}
@@ -25,17 +86,31 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Semantic Release
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.19.5'
+      - name: Install semantic-release
+        run: |
+          npm install -g \
+            semantic-release@24 \
+            @semantic-release/commit-analyzer@13 \
+            @semantic-release/release-notes-generator@14 \
+            @semantic-release/github@11
+      - name: Run semantic-release
         id: semantic
-        uses: cycjimmy/semantic-release-action@v4
+        run: |
+          BEFORE=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | tail -1)
+          semantic-release
+          AFTER=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | tail -1)
+          if [ -n "$AFTER" ] && [ "$AFTER" != "$BEFORE" ]; then
+            echo "new_release_published=true" >> $GITHUB_OUTPUT
+            echo "new_release_version=${AFTER#v}" >> $GITHUB_OUTPUT
+          else
+            echo "new_release_published=false" >> $GITHUB_OUTPUT
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          semantic_version: 24
-          extra_plugins: |
-            @semantic-release/commit-analyzer
-            @semantic-release/release-notes-generator
-            @semantic-release/github
 
   publish:
     name: Publish Docker images

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,12 +38,18 @@ jobs:
 
           LAST_TAG=$(git tag -l "v${MAJOR}.${MINOR}.*" | sort -V | tail -1)
           if [ -z "$LAST_TAG" ]; then
-            echo "No existing tags for v${MAJOR}.${MINOR}.x — this will be the first patch in this maintenance series."
-            RANGE="HEAD"
+            # No prior patch in this series — fall back to the ancestor tag the branch was cut from.
+            # Without this fallback RANGE="HEAD" would scan all history and trip on historical feat: commits.
+            LAST_TAG=$(git describe --tags --abbrev=0 HEAD 2>/dev/null)
+            if [ -z "$LAST_TAG" ]; then
+              echo "No tags found in repository — skipping commit range validation."
+              exit 0
+            fi
+            echo "No existing v${MAJOR}.${MINOR}.x tags — validating commits since $LAST_TAG"
           else
             echo "Last tag in maintenance series: $LAST_TAG"
-            RANGE="${LAST_TAG}..HEAD"
           fi
+          RANGE="${LAST_TAG}..HEAD"
 
           SUBJECTS=$(git log --format="%s" $RANGE)
           BODIES=$(git log --format="%B" $RANGE)

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,9 @@
+{
+  "branches": ["main"],
+  "tagFormat": "v${version}",
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/github"
+  ]
+}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,9 +1,0 @@
-{
-  "branches": ["main"],
-  "tagFormat": "v${version}",
-  "plugins": [
-    "@semantic-release/commit-analyzer",
-    "@semantic-release/release-notes-generator",
-    "@semantic-release/github"
-  ]
-}

--- a/README.md
+++ b/README.md
@@ -41,12 +41,12 @@ This project uses [semantic-release](https://github.com/semantic-release/semanti
 
 Releases are created manually by running the **Create Release** workflow from the GitHub Actions UI. Selecting `main` cuts a regular release; selecting a `release/vX.Y` branch cuts a patch-only maintenance release.
 
-| Commit prefix | Version bump |
-|---|---|
-| `fix:` | Patch (`1.0.x`) |
-| `feat:` | Minor (`1.x.0`) |
-| `feat!:` / `BREAKING CHANGE:` | Major (`x.0.0`) |
-| `chore:`, `docs:`, `ci:`, etc. | Patch |
+| Commit prefix                  | Version bump    |
+| ------------------------------ | --------------- |
+| `fix:`                         | Patch (`1.0.x`) |
+| `feat:`                        | Minor (`1.x.0`) |
+| `feat!:` / `BREAKING CHANGE:`  | Major (`x.0.0`) |
+| `chore:`, `docs:`, `ci:`, etc. | Patch           |
 
 ## Local Development Environment
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,19 @@ Never heard of Interledger before, or you would like to learn more? Here are som
 
 Please read the [contribution guidelines](.github/contributing.md) before submitting contributions. All contributions must adhere to our [code of conduct](.github/CODE_OF_CONDUCT.md).
 
+## Releases
+
+This project uses [semantic-release](https://github.com/semantic-release/semantic-release) with [Conventional Commits](https://www.conventionalcommits.org/). PR titles are automatically validated to follow the `type(scope): description` format.
+
+Releases are created manually by running the **Create Release** workflow from the GitHub Actions UI. Selecting `main` cuts a regular release; selecting a `release/vX.Y` branch cuts a patch-only maintenance release.
+
+| Commit prefix | Version bump |
+|---|---|
+| `fix:` | Patch (`1.0.x`) |
+| `feat:` | Minor (`1.x.0`) |
+| `feat!:` / `BREAKING CHANGE:` | Major (`x.0.0`) |
+| `chore:`, `docs:`, `ci:`, etc. | Patch |
+
 ## Local Development Environment
 
 ### Prerequisites

--- a/release.config.js
+++ b/release.config.js
@@ -11,7 +11,7 @@ if (maintenanceMatch) {
     name: branch,
     range: `${major}.${minor}.x`,
     channel: 'maintenance',
-    prerelease: false,
+    prerelease: false
   })
 }
 
@@ -38,11 +38,11 @@ module.exports = {
           { type: 'refactor', release: 'patch' },
           { type: 'test', release: 'patch' },
           { type: 'build', release: 'patch' },
-          { type: 'ci', release: 'patch' },
-        ],
-      },
+          { type: 'ci', release: 'patch' }
+        ]
+      }
     ],
     '@semantic-release/release-notes-generator',
-    '@semantic-release/github',
-  ],
+    '@semantic-release/github'
+  ]
 }

--- a/release.config.js
+++ b/release.config.js
@@ -1,0 +1,48 @@
+// Maintenance branches (release/vX.Y) are added dynamically so semantic-release
+// accepts whichever branch the workflow is triggered against, without needing
+// to hardcode every future maintenance branch in advance.
+const branch = process.env.GITHUB_REF_NAME || 'main'
+const maintenanceMatch = branch.match(/^release\/v(\d+)\.(\d+)$/)
+
+const branches = ['main']
+if (maintenanceMatch) {
+  const [, major, minor] = maintenanceMatch
+  branches.push({
+    name: branch,
+    range: `${major}.${minor}.x`,
+    channel: 'maintenance',
+    prerelease: false,
+  })
+}
+
+module.exports = {
+  branches,
+  tagFormat: 'v${version}',
+  plugins: [
+    [
+      '@semantic-release/commit-analyzer',
+      {
+        // Every conventional commit type triggers at least a patch so that
+        // running "Create Release" always produces a new version, even if the
+        // branch contains only chore/docs/ci commits.
+        releaseRules: [
+          { breaking: true, release: 'major' },
+          { revert: true, release: 'patch' },
+          { type: 'feat', release: 'minor' },
+          { type: 'fix', release: 'patch' },
+          { type: 'perf', release: 'patch' },
+          { type: 'revert', release: 'patch' },
+          { type: 'chore', release: 'patch' },
+          { type: 'docs', release: 'patch' },
+          { type: 'style', release: 'patch' },
+          { type: 'refactor', release: 'patch' },
+          { type: 'test', release: 'patch' },
+          { type: 'build', release: 'patch' },
+          { type: 'ci', release: 'patch' },
+        ],
+      },
+    ],
+    '@semantic-release/release-notes-generator',
+    '@semantic-release/github',
+  ],
+}


### PR DESCRIPTION
### Context

As part of our effort to mature the CI of this repository, this PR proposes the full migration to formalised `semantic-release`. 

This PR reworks the release mechanisms to be much more simple and automated. Developers simply need to trigger the "Create Release" workflow to trigger the creation of a new release. Version number will be calculated using conventional commits.