### PR TITLE
feat(boutique): boutique configuration at deploy time

### DIFF
--- a/packages/boutique/backend/jest.setup.js
+++ b/packages/boutique/backend/jest.setup.js
@@ -4,7 +4,6 @@ const { randomBytes, generateKeyPairSync } = require('crypto')
 const POSTGRES_PASSWORD = 'password'
 const POSTGRES_DB = randomBytes(16).toString('hex')
 const POSTGRES_PORT = 5432
-const REDIS_PORT = 6379
 
 module.exports = async () => {
   const container = await new GenericContainer('postgres:15')
@@ -13,10 +12,6 @@ module.exports = async () => {
       POSTGRES_DB
     })
     .withExposedPorts(POSTGRES_PORT)
-    .start()
-
-  const redisContainer = await new GenericContainer('redis:7')
-    .withExposedPorts(REDIS_PORT)
     .start()
 
   // env.ts requires these variables without defaults, so we supply
@@ -37,8 +32,6 @@ module.exports = async () => {
       })
       .trim()
   ).toString('base64')
-  process.env.REDIS_URL = `redis://localhost:${redisContainer.getMappedPort(REDIS_PORT)}/0`
 
   global.__POSTGRES_CONTAINER__ = container
-  global.__TESTING_REDIS_CONTAINER__ = redisContainer
 }

--- a/packages/boutique/backend/jest.teardown.js
+++ b/packages/boutique/backend/jest.teardown.js
@@ -2,7 +2,4 @@ module.exports = async () => {
   if (global.__POSTGRES_CONTAINER__) {
     await global.__POSTGRES_CONTAINER__.stop()
   }
-  if (global.__TESTING_REDIS_CONTAINER__) {
-    await global.__TESTING_REDIS_CONTAINER__.stop()
-  }
 }

--- a/packages/boutique/backend/src/config/env.ts
+++ b/packages/boutique/backend/src/config/env.ts
@@ -34,7 +34,6 @@ const envSchema = z.object({
   PAYMENT_POINTER: httpsUrlString,
   KEY_ID: requiredString,
   PRIVATE_KEY: base64String,
-  REDIS_URL: z.string().url(),
   USE_HTTP_FOR_OPEN_PAYMENTS: z.boolean().optional()
 })
 

--- a/packages/boutique/frontend/Dockerfile.prod
+++ b/packages/boutique/frontend/Dockerfile.prod
@@ -30,14 +30,8 @@ COPY --from=base /testnet/packages/boutique/frontend/node_modules ./packages/bou
 COPY --from=base /testnet/packages/boutique/shared/node_modules ./packages/boutique/shared/node_modules
 
 ARG PORT
-ARG VITE_API_BASE_URL
-ARG VITE_CURRENCY
-ARG VITE_THEME
 
 ENV NODE_ENV=production
-ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
-ENV VITE_CURRENCY=$VITE_CURRENCY
-ENV VITE_THEME=$VITE_THEME
 
 RUN pnpm boutique:frontend build
 
@@ -46,7 +40,9 @@ FROM nginx:stable-alpine AS runner
 COPY --from=builder /testnet/packages/boutique/frontend/dist /usr/share/nginx/html
 COPY --from=builder /testnet/packages/boutique/shared/package.json ./packages/boutique/shared/package.json
 COPY packages/boutique/frontend/nginx/nginx.conf /etc/nginx/conf.d/default.conf
+COPY packages/boutique/frontend/docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
 
 EXPOSE ${PORT}
 
-CMD ["nginx", "-g", "daemon off;"]
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/packages/boutique/frontend/Dockerfile.prod
+++ b/packages/boutique/frontend/Dockerfile.prod
@@ -43,6 +43,6 @@ COPY packages/boutique/frontend/nginx/nginx.conf /etc/nginx/conf.d/default.conf
 COPY packages/boutique/frontend/docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh
 
-EXPOSE ${PORT}
+EXPOSE 4004
 
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/packages/boutique/frontend/docker-entrypoint.sh
+++ b/packages/boutique/frontend/docker-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+cat > /usr/share/nginx/html/env.js << EOF
+window.__env__ = {
+  API_BASE_URL: '${API_BASE_URL:-}',
+  THEME: '${THEME:-}',
+  CURRENCY: '${CURRENCY:-}',
+};
+EOF
+
+exec nginx -g "daemon off;"

--- a/packages/boutique/frontend/index.html
+++ b/packages/boutique/frontend/index.html
@@ -8,6 +8,7 @@
   </head>
   <body class="h-full">
     <div id="root"></div>
+    <script src="/env.js"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/packages/boutique/frontend/nginx/nginx.conf
+++ b/packages/boutique/frontend/nginx/nginx.conf
@@ -10,9 +10,13 @@ server {
     gzip_types text/plain application/xml text/css application/javascript;
     gzip_vary on;
 
+    location = /env.js {
+        add_header Cache-Control "no-store";
+    }
+
     location / {
         try_files $uri $uri/ /index.html =404;
-        
+
         location ~* \.(js|css|png|jpg|jpeg|gif|svg|woff|woff2|ttf|eot|ico)$ {
             expires 30d;
             add_header Cache-Control "public, max-age=2592000";

--- a/packages/boutique/frontend/public/env.js
+++ b/packages/boutique/frontend/public/env.js
@@ -1,0 +1,5 @@
+window.__env__ = {
+  API_BASE_URL: '',
+  THEME: '',
+  CURRENCY: '',
+}

--- a/packages/boutique/frontend/src/lib/constants.ts
+++ b/packages/boutique/frontend/src/lib/constants.ts
@@ -30,7 +30,10 @@ const getDefaultApiBaseUrl = () => {
 }
 
 export const API_BASE_URL =
-  windowEnv?.API_BASE_URL || import.meta.env.VITE_API_BASE_URL || getDefaultApiBaseUrl()
+  windowEnv?.API_BASE_URL ||
+  import.meta.env.VITE_API_BASE_URL ||
+  getDefaultApiBaseUrl()
 export const IMAGES_URL = API_BASE_URL + '/images/'
 export const THEME = windowEnv?.THEME || import.meta.env.VITE_THEME || 'light'
-export const CURRENCY = windowEnv?.CURRENCY || import.meta.env.VITE_CURRENCY || 'USD'
+export const CURRENCY =
+  windowEnv?.CURRENCY || import.meta.env.VITE_CURRENCY || 'USD'

--- a/packages/boutique/frontend/src/lib/constants.ts
+++ b/packages/boutique/frontend/src/lib/constants.ts
@@ -1,4 +1,4 @@
-  declare global {
+declare global {
   interface Window {
     __env__?: {
       API_BASE_URL?: string

--- a/packages/boutique/frontend/src/lib/constants.ts
+++ b/packages/boutique/frontend/src/lib/constants.ts
@@ -1,3 +1,15 @@
+declare global {
+  interface Window {
+    __env__?: {
+      API_BASE_URL?: string
+      THEME?: string
+      CURRENCY?: string
+    }
+  }
+}
+
+const windowEnv = typeof window !== 'undefined' ? window.__env__ : undefined
+
 // Resolve the boutique API base URL at runtime based on the current hostname.
 // In the local HTTPS environment the frontend is served behind Traefik at
 // "boutique.test", so we route API calls to its TLS-proxied backend.
@@ -12,12 +24,13 @@ const getDefaultApiBaseUrl = () => {
 
   console.warn(
     'Boutique API: falling back to http://localhost:3004. ' +
-      'Set VITE_API_BASE_URL or access via boutique.test for the local HTTPS environment.'
+      'Set API_BASE_URL (runtime) or VITE_API_BASE_URL (build-time), or access via boutique.test.'
   )
   return 'http://localhost:3004'
 }
 
 export const API_BASE_URL =
-  import.meta.env.VITE_API_BASE_URL || getDefaultApiBaseUrl()
+  windowEnv?.API_BASE_URL || import.meta.env.VITE_API_BASE_URL || getDefaultApiBaseUrl()
 export const IMAGES_URL = API_BASE_URL + '/images/'
-export const THEME = import.meta.env.VITE_THEME || 'light'
+export const THEME = windowEnv?.THEME || import.meta.env.VITE_THEME || 'light'
+export const CURRENCY = windowEnv?.CURRENCY || import.meta.env.VITE_CURRENCY || 'USD'

--- a/packages/boutique/frontend/src/lib/constants.ts
+++ b/packages/boutique/frontend/src/lib/constants.ts
@@ -1,4 +1,4 @@
-declare global {
+  declare global {
   interface Window {
     __env__?: {
       API_BASE_URL?: string

--- a/packages/boutique/frontend/src/lib/utils.ts
+++ b/packages/boutique/frontend/src/lib/utils.ts
@@ -7,14 +7,19 @@ export function cn(...inputs: CxOptions) {
 }
 
 export function formatPrice(price: number): string {
-  const formatter = new Intl.NumberFormat('en-US', {
+  let currency = CURRENCY
+  try {
+    new Intl.NumberFormat('en-US', { style: 'currency', currency })
+  } catch {
+    currency = 'USD'
+  }
+
+  return new Intl.NumberFormat('en-US', {
     style: 'currency',
-    currency: CURRENCY,
+    currency,
     maximumFractionDigits: 2,
     minimumFractionDigits: 2
-  })
-
-  return formatter.format(price)
+  }).format(price)
 }
 
 export const getObjectKeys = Object.keys as <T extends object>(

--- a/packages/boutique/frontend/src/lib/utils.ts
+++ b/packages/boutique/frontend/src/lib/utils.ts
@@ -1,5 +1,6 @@
 import { type CxOptions, cx } from 'class-variance-authority'
 import { twMerge } from 'tailwind-merge'
+import { CURRENCY } from '@/lib/constants'
 
 export function cn(...inputs: CxOptions) {
   return twMerge(cx(inputs))
@@ -8,7 +9,7 @@ export function cn(...inputs: CxOptions) {
 export function formatPrice(price: number): string {
   const formatter = new Intl.NumberFormat('en-US', {
     style: 'currency',
-    currency: import.meta.env.VITE_CURRENCY || 'USD',
+    currency: CURRENCY,
     maximumFractionDigits: 2,
     minimumFractionDigits: 2
   })

--- a/packages/boutique/frontend/src/main.tsx
+++ b/packages/boutique/frontend/src/main.tsx
@@ -1,6 +1,9 @@
 import ReactDOM from 'react-dom/client'
 import { App } from './app/index.tsx'
 import './main.css'
+import { THEME } from '@/lib/constants'
+
+document.documentElement.classList.add(THEME)
 
 // fonts
 import './fonts/DejaVuSansMono.ttf'

--- a/packages/boutique/frontend/vite.config.ts
+++ b/packages/boutique/frontend/vite.config.ts
@@ -3,19 +3,7 @@ import react from '@vitejs/plugin-react-swc'
 import { resolve } from 'node:path'
 
 export default defineConfig({
-  plugins: [
-    react(),
-    {
-      name: 'html-transform',
-      transformIndexHtml(html) {
-        // Read the theme from the environment variable
-        return html.replace(
-          '<html class="',
-          `<html class="${process.env.VITE_THEME ?? 'light'} `
-        )
-      }
-    }
-  ],
+  plugins: [react()],
   server: {
     host: '0.0.0.0',
     allowedHosts: ['boutique.test'],


### PR DESCRIPTION
In order to streamline our deployment process, we need to be able to configure boutique frontend specific variables during deploy time instead of build time.

This PR introduces a small entrypoint script that injects environmental variables into a folder where the application can pick it up and consume from there. This way a deployment can set these variables during deploy time.

---

## Auto generated

This pull request introduces runtime configuration for environment variables in the Boutique frontend, enabling dynamic updates to settings like API base URL, theme, and currency without requiring a rebuild. The changes include a new entrypoint script for Docker-based deployments, adjustments to how environment variables are injected and consumed in the frontend, and the removal of now-unnecessary build-time environment variables. This makes the frontend more flexible and easier to configure in different environments.

**Runtime environment variable injection and usage:**

* Added a `docker-entrypoint.sh` script to the frontend Docker image, which generates a `env.js` file at container startup with runtime values for `API_BASE_URL`, `THEME`, and `CURRENCY`. The frontend now loads these variables at runtime instead of at build time. (`packages/boutique/frontend/docker-entrypoint.sh`, `packages/boutique/frontend/Dockerfile.prod`, `packages/boutique/frontend/index.html`) [[1]](diffhunk://#diff-3b7daa191ffdb6a01ab73914e76fce0372a3af51b7233ca3345132a4e37fc764R1-R12) [[2]](diffhunk://#diff-3abc11b187092d4cbad1340adaedd33e9099e3934f291c78a611a668dd2b8896R43-R48) [[3]](diffhunk://#diff-6126dc083fe3b59e6999a73ff565f842856e6da6180b3f000d5f91cadb5d78a6R11)
* Updated the frontend code to read configuration values from `window.__env__` (populated by `env.js`) with fallback to build-time variables and sensible defaults. This affects constants and utility functions for API base URL, theme, and currency. (`packages/boutique/frontend/src/lib/constants.ts`, `packages/boutique/frontend/src/lib/utils.ts`, `packages/boutique/frontend/src/main.tsx`) [[1]](diffhunk://#diff-24a0948a4be9b95b2e1d962e62cedfb10d58bd896e91334d60dd585aa54a7c9dR1-R12) [[2]](diffhunk://#diff-24a0948a4be9b95b2e1d962e62cedfb10d58bd896e91334d60dd585aa54a7c9dL15-R39) [[3]](diffhunk://#diff-299073a8b0c28b5eacfff25d4d85d81999a50e9e7c9805d3129c9f3ddeb9e929R3) [[4]](diffhunk://#diff-299073a8b0c28b5eacfff25d4d85d81999a50e9e7c9805d3129c9f3ddeb9e929L11-R12) [[5]](diffhunk://#diff-6147f2b56a507773819c0ed654ae7b2cb2a241b27b38324923bec3f367dd953fR4-R6)

**Build process and configuration cleanup:**

* Removed `VITE_API_BASE_URL`, `VITE_CURRENCY`, and `VITE_THEME` from the Docker build process and environment, as these are now set at runtime. (`packages/boutique/frontend/Dockerfile.prod`)
* Simplified the Vite config by removing the custom HTML transform plugin that previously injected the theme at build time. (`packages/boutique/frontend/vite.config.ts`)

**Supporting files:**

* Added a default (empty) `env.js` to the public directory to ensure the variable exists in development or non-Docker environments. (`packages/boutique/frontend/public/env.js`)

**Other minor changes:**

* Cleaned up the backend environment schema by removing an unused `REDIS_URL` variable. (`packages/boutique/backend/src/config/env.ts`)