### PR TITLE
ci: should now be able to publish helm from release workflow

### DIFF
--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -4,6 +4,14 @@ on:
   release:
     types:
       - published
+  workflow_call:
+    inputs:
+      tag_name:
+        required: true
+        type: string
+    secrets:
+      HELM_PUBLISH_TOKEN:
+        required: true
 
 jobs:
   publish:
@@ -20,7 +28,7 @@ jobs:
 
       - name: Update and package all charts
         run: |
-          TAG="${{ github.event.release.tag_name }}"
+          TAG="${{ inputs.tag_name || github.event.release.tag_name }}"
           VERSION="${TAG#v}"
           APP_VERSION="$TAG"
           mkdir -p /tmp/helm-package
@@ -43,7 +51,7 @@ jobs:
           cp /tmp/helm-package/*.tgz charts-branch/
           cd charts-branch
           helm repo index . \
-            --url https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
+            --url https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name || 'testnet' }}
 
       - name: Commit and push to charts branch
         run: |

--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.tag_name || github.event.release.tag_name }}
 
       - name: Install Helm
         uses: azure/setup-helm@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  helm-publish:
+    name: Publish Helm charts
+    needs: release
+    if: needs.release.outputs.new_release_published == 'true'
+    uses: ./.github/workflows/helm-publish.yml
+    with:
+      tag_name: v${{ needs.release.outputs.new_release_version }}
+    secrets: inherit
+
   publish:
     name: Publish Docker images
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,8 @@ jobs:
     uses: ./.github/workflows/helm-publish.yml
     with:
       tag_name: v${{ needs.release.outputs.new_release_version }}
-    secrets: inherit
+    secrets:
+      HELM_PUBLISH_TOKEN: ${{ secrets.HELM_PUBLISH_TOKEN }}
 
   publish:
     name: Publish Docker images


### PR DESCRIPTION
Github prevents firing of workflow events if the release is created using the normal GITHUB_TOKEN mechanism. This is an anti-loop protection mechanism which now preveted our helm chart releases from publishing.

This PR attempts to resolve this issue with a workaround calling the helm publishing workflow directly during release process.

---

## Auto generated

This pull request updates the Helm chart publishing workflow to support both manual and automated triggers, and improves flexibility in how release information is passed between workflows. The main changes add support for workflow calls, allow dynamic tag and repository name handling, and integrate the Helm publish workflow into the main release process.

Workflow enhancements and integration:

* Added support for triggering the `helm-publish` workflow via `workflow_call` with required `tag_name` input and `HELM_PUBLISH_TOKEN` secret, enabling reuse and manual invocation.
* Integrated the `helm-publish` workflow into the main `release.yml` pipeline, so Helm charts are published automatically after a new release is published. The workflow is triggered with the new release version as the tag.

Parameter and flexibility improvements:

* Updated the tag selection logic in the Helm publish workflow to use the `inputs.tag_name` if provided, falling back to `github.event.release.tag_name` for backward compatibility.
* Modified the Helm repo index URL to use a fallback value (`'testnet'`) if `github.event.repository.name` is not set, improving robustness for different invocation contexts.