### PR TITLE
ci: publishing helm will now correctly include archives

### DIFF
--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -60,6 +60,7 @@ jobs:
           cd charts-branch
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .
+          git add -f *.tgz
+          git add index.yaml
           git diff --cached --quiet || git commit -m "chore: publish helm charts"
           git push


### PR DESCRIPTION
This PR fixes a bug in the helm publishing process where tar archives were not being included when publishing.