### PR TITLE
fix: Deposit popup flickering

### DIFF
--- a/packages/wallet/frontend/src/pages/_app.tsx
+++ b/packages/wallet/frontend/src/pages/_app.tsx
@@ -5,13 +5,12 @@ import { AppProvider } from '@/components/providers'
 import { Progress } from '@/ui/Progress'
 import type { AppPropsWithLayout } from '@/lib/types/app'
 import { MoneyBird } from '@/components/icons/MoneyBird'
-import { useToast } from '@/lib/hooks/useToast'
 import { io, Socket } from 'socket.io-client'
 import { useEffect } from 'react'
 import { updateBalance } from '@/lib/balance'
 import { formatAmount } from '@/utils/helpers'
 import { FEATURES_ENABLED } from '@/utils/constants'
-
+import { toast } from '@/lib/hooks/useToast'
 const font = localFont({
   src: [
     {
@@ -31,7 +30,6 @@ const font = localFont({
 
 export default function App({ Component, pageProps }: AppPropsWithLayout) {
   const getLayout = Component.getLayout ?? ((page) => page)
-  const { toast } = useToast()
 
   useEffect(() => {
     let socket: Socket | null = null
@@ -126,7 +124,7 @@ export default function App({ Component, pageProps }: AppPropsWithLayout) {
     return () => {
       socket?.disconnect()
     }
-  }, [toast])
+  }, [])
 
   return (
     <>

--- a/packages/wallet/frontend/src/pages/_app.tsx
+++ b/packages/wallet/frontend/src/pages/_app.tsx
@@ -11,6 +11,7 @@ import { updateBalance } from '@/lib/balance'
 import { formatAmount } from '@/utils/helpers'
 import { FEATURES_ENABLED } from '@/utils/constants'
 import { toast } from '@/lib/hooks/useToast'
+
 const font = localFont({
   src: [
     {


### PR DESCRIPTION
### Context

fixes [INT1-Deposit popup flickering](https://linear.app/interledger/issue/INT1-643/deposit-popup-flickering)

### Changes

Updated _app.tsx to use toast instead of useToast() because it only needs to trigger toast notifications from socket events and not from every toast state. Using useToast() caused the rerender of the page whenever the state changed.