### PR TITLE
feat: Warn Users about big deposits

### DIFF
--- a/packages/wallet/frontend/src/components/dialogs/DepositDialog.tsx
+++ b/packages/wallet/frontend/src/components/dialogs/DepositDialog.tsx
@@ -80,7 +80,6 @@ export const DepositDialog = ({
                   After hitting the ~$10,000 USD daily deposit limit,
                   you&apos;ll receive your funds in about 5 minutes.
                 </p>
-
                 <Form
                   form={depositForm}
                   onSubmit={async (data) => {

--- a/packages/wallet/frontend/src/components/dialogs/DepositDialog.tsx
+++ b/packages/wallet/frontend/src/components/dialogs/DepositDialog.tsx
@@ -16,6 +16,7 @@ import { getCurrencySymbol } from '@/utils/helpers'
 import { accountService, depositSchema } from '@/lib/api/account'
 import { useToast } from '@/lib/hooks/useToast'
 import { MoneyBird } from '../icons/MoneyBird'
+import { Warning } from '../icons/Warning'
 
 type DepositDialogProps = Pick<DialogProps, 'onClose'> & {
   accountId: string
@@ -71,6 +72,15 @@ export const DepositDialog = ({
                 <p className="text-xs text-center">
                   A small fee might be applied when making a deposit.
                 </p>
+                <p className=" text-xs text-center">
+                  <Warning
+                    strokeWidth={2}
+                    className="mr-2 inline-flex h-7 w-7 items-center justify-center"
+                  />
+                  After hitting the ~$10,000 USD daily deposit limit,
+                  you&apos;ll receive your funds in about 5 minutes.
+                </p>
+
                 <Form
                   form={depositForm}
                   onSubmit={async (data) => {


### PR DESCRIPTION
### Context

 fixes #INT1-670 | Warn users about big deposits

### Changes

- Add a warning message inside Deposit Dialog to let users know that deposits over ~10k USD may take 5 Minutes to be processed.