### PR TITLE
ci: local environment checks health before creating assets

### DIFF
--- a/local/postgres.yaml
+++ b/local/postgres.yaml
@@ -13,3 +13,13 @@ services:
     volumes:
       - pg-data:/var/lib/postgresql/data
       - ./init/dbinit.sql:/docker-entrypoint-initdb.d/init.sql
+    # Gate dependents (rafiki-*) on real readiness. On a fresh volume Postgres
+    # runs initdb + dbinit.sql (5 DBs) before accepting TCP connections, which
+    # can take tens of seconds — especially on macOS/Docker Desktop.
+    healthcheck:
+      test:
+        ['CMD-SHELL', 'pg_isready -U ${POSTGRES_USER:-postgres} -d postgres']
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 10s

--- a/local/rafiki.yaml
+++ b/local/rafiki.yaml
@@ -40,7 +40,11 @@ services:
       - boutique.test:host-gateway
       - api.boutique.test:host-gateway
     depends_on:
-      - postgres
+      # Wait for Postgres to accept connections before booting. Otherwise the
+      # startup migration fails, start() throws (only logged, not fatal) and the
+      # admin server never starts while the container restart-loops.
+      postgres:
+        condition: service_healthy
     labels:
       - traefik.enable=true
       - traefik.docker.network=testnet
@@ -118,8 +122,15 @@ services:
       POS_SERVICE_URL: ${RAFIKI_BACKEND_POS_SERVICE_URL:-http://rafiki-pos-service:3014}
       POS_WEBHOOK_SERVICE_URL: ${RAFIKI_BACKEND_POS_WEBHOOK_SERVICE_URL:-http://rafiki-pos-service:3014/web}
     depends_on:
-      - postgres
-      - redis
+      # Wait for Postgres/Redis readiness before booting. Otherwise the startup
+      # migration + operator-tenant seed fails, start() throws (only logged),
+      # the admin server never comes up and the container restart-loops — which
+      # makes the rafiki-assets setup step time out and silently skip creating
+      # the default USD/EUR assets.
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     extra_hosts:
       - host.docker.internal:host-gateway
       - testnet.test:host-gateway

--- a/local/redis.yaml
+++ b/local/redis.yaml
@@ -9,3 +9,9 @@ services:
       - '6379:6379'
     volumes:
       - redis-data:/data
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 5s

--- a/local/scripts/rafiki-setup.js
+++ b/local/scripts/rafiki-setup.js
@@ -104,7 +104,10 @@ function buildEnv() {
     // Readiness gating (tunable for slow first-runs, e.g. macOS/Docker Desktop
     // where a fresh Postgres volume takes a while to initialise).
     READINESS_INITIAL_DELAY_MS: (() => {
-      const n = Number.parseInt(get('RAFIKI_SETUP_INITIAL_DELAY_MS', '3000'), 10)
+      const n = Number.parseInt(
+        get('RAFIKI_SETUP_INITIAL_DELAY_MS', '3000'),
+        10
+      )
       return Number.isFinite(n) && n >= 0 ? n : 3000
     })(),
     READINESS_MAX_ATTEMPTS: (() => {
@@ -112,7 +115,10 @@ function buildEnv() {
       return Number.isFinite(n) && n > 0 ? n : 90
     })(),
     READINESS_RETRY_INTERVAL_MS: (() => {
-      const n = Number.parseInt(get('RAFIKI_SETUP_RETRY_INTERVAL_MS', '2000'), 10)
+      const n = Number.parseInt(
+        get('RAFIKI_SETUP_RETRY_INTERVAL_MS', '2000'),
+        10
+      )
       return Number.isFinite(n) && n >= 0 ? n : 2000
     })(),
     ADMIN_API_SECRET: get('ADMIN_API_SECRET', 'secret-key'),

--- a/local/scripts/rafiki-setup.js
+++ b/local/scripts/rafiki-setup.js
@@ -92,11 +92,23 @@ function buildEnv() {
   const fileEnv = loadDotEnv(envPath)
   const get = (key, fallback) => process.env[key] ?? fileEnv[key] ?? fallback
 
+  // Default to 127.0.0.1 (not "localhost"): Node 18+ resolves "localhost"
+  // verbatim and may prefer IPv6 (::1), which fails against Docker's
+  // IPv4-only published ports and makes every request hang/ECONNREFUSED.
   const env = {
-    GRAPHQL_ENDPOINT: get('GRAPHQL_ENDPOINT', 'http://localhost:3011/graphql'),
+    GRAPHQL_ENDPOINT: get('GRAPHQL_ENDPOINT', 'http://127.0.0.1:3011/graphql'),
     RAFIKI_HEALTH_ENDPOINT: get(
       'RAFIKI_HEALTH_ENDPOINT',
-      'http://localhost:3011/healthz'
+      'http://127.0.0.1:3011/healthz'
+    ),
+    // Readiness gating (tunable for slow first-runs, e.g. macOS/Docker Desktop
+    // where a fresh Postgres volume takes a while to initialise).
+    READINESS_INITIAL_DELAY_MS: Number(
+      get('RAFIKI_SETUP_INITIAL_DELAY_MS', '3000')
+    ),
+    READINESS_MAX_ATTEMPTS: Number(get('RAFIKI_SETUP_MAX_ATTEMPTS', '90')),
+    READINESS_RETRY_INTERVAL_MS: Number(
+      get('RAFIKI_SETUP_RETRY_INTERVAL_MS', '2000')
     ),
     ADMIN_API_SECRET: get('ADMIN_API_SECRET', 'secret-key'),
     ADMIN_SIGNATURE_VERSION: get('ADMIN_SIGNATURE_VERSION', '1'),
@@ -132,9 +144,9 @@ function sleep(ms) {
 }
 
 async function waitForRafikiHealth(env) {
-  const initialDelayMs = 3000
-  const maxAttempts = 30
-  const retryIntervalMs = 2000
+  const initialDelayMs = env.READINESS_INITIAL_DELAY_MS
+  const maxAttempts = env.READINESS_MAX_ATTEMPTS
+  const retryIntervalMs = env.READINESS_RETRY_INTERVAL_MS
 
   logInfo(
     `Waiting ${initialDelayMs / 1000}s for containers to initialise before polling health`
@@ -176,6 +188,39 @@ async function waitForRafikiHealth(env) {
 
   throw new Error(
     `Rafiki health endpoint did not return OK after ${initialDelayMs / 1000}s initial wait + ${maxAttempts} attempts`
+  )
+}
+
+// /healthz only proves Postgres/Redis are reachable — not that the admin
+// GraphQL API is answering authenticated (signed) requests yet. Probe a real
+// signed query so subsequent mutations don't fail on a transient 401/5xx.
+async function waitForAdminApiReady(env) {
+  const maxAttempts = env.READINESS_MAX_ATTEMPTS
+  const retryIntervalMs = env.READINESS_RETRY_INTERVAL_MS
+
+  logInfo('Probing Rafiki admin GraphQL API for readiness')
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      await graphqlRequest(
+        { query: getTenantQuery, variables: { id: env.OPERATOR_TENANT_ID } },
+        env
+      )
+      logInfo('Rafiki admin GraphQL API is ready')
+      return
+    } catch (err) {
+      logInfo(
+        `Admin API not ready yet (${attempt}/${maxAttempts}): ${err.message}`
+      )
+    }
+
+    if (attempt < maxAttempts) {
+      await sleep(retryIntervalMs)
+    }
+  }
+
+  throw new Error(
+    `Rafiki admin GraphQL API did not become ready after ${maxAttempts} attempts`
   )
 }
 
@@ -403,8 +448,10 @@ async function ensureAssets(env) {
   logInfo('Target assets:', assetsToEnsure)
   let current = { assets: { edges: [] } }
   try {
+    // Rafiki caps pagination `first` at 100 (baseModel.ts throws
+    // "Pagination index error" above that). We only ensure a couple of assets.
     current = await graphqlRequest(
-      { query: listAssetsQuery, variables: { first: 200 } },
+      { query: listAssetsQuery, variables: { first: 100 } },
       env
     )
     logInfo(
@@ -532,6 +579,7 @@ async function ensureLiquidity(env) {
   logInfo('Starting Rafiki setup script')
   logInfo('Rafiki admin endpoint:', env.GRAPHQL_ENDPOINT)
   await waitForRafikiHealth(env)
+  await waitForAdminApiReady(env)
   await ensureTenant(env)
   await ensureAssets(env)
   await ensureLiquidity(env)

--- a/local/scripts/rafiki-setup.js
+++ b/local/scripts/rafiki-setup.js
@@ -103,13 +103,18 @@ function buildEnv() {
     ),
     // Readiness gating (tunable for slow first-runs, e.g. macOS/Docker Desktop
     // where a fresh Postgres volume takes a while to initialise).
-    READINESS_INITIAL_DELAY_MS: Number(
-      get('RAFIKI_SETUP_INITIAL_DELAY_MS', '3000')
-    ),
-    READINESS_MAX_ATTEMPTS: Number(get('RAFIKI_SETUP_MAX_ATTEMPTS', '90')),
-    READINESS_RETRY_INTERVAL_MS: Number(
-      get('RAFIKI_SETUP_RETRY_INTERVAL_MS', '2000')
-    ),
+    READINESS_INITIAL_DELAY_MS: (() => {
+      const n = Number.parseInt(get('RAFIKI_SETUP_INITIAL_DELAY_MS', '3000'), 10)
+      return Number.isFinite(n) && n >= 0 ? n : 3000
+    })(),
+    READINESS_MAX_ATTEMPTS: (() => {
+      const n = Number.parseInt(get('RAFIKI_SETUP_MAX_ATTEMPTS', '90'), 10)
+      return Number.isFinite(n) && n > 0 ? n : 90
+    })(),
+    READINESS_RETRY_INTERVAL_MS: (() => {
+      const n = Number.parseInt(get('RAFIKI_SETUP_RETRY_INTERVAL_MS', '2000'), 10)
+      return Number.isFinite(n) && n >= 0 ? n : 2000
+    })(),
     ADMIN_API_SECRET: get('ADMIN_API_SECRET', 'secret-key'),
     ADMIN_SIGNATURE_VERSION: get('ADMIN_SIGNATURE_VERSION', '1'),
     OPERATOR_TENANT_ID: get(

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "checks": "pnpm prettier:check && pnpm lint:check",
     "test": "pnpm test:unit",
     "test:unit": "pnpm boutique:backend test && pnpm wallet:backend test",
-    "clean": "pnpm clean:modules && pnpm clean:builds",
+    "clean": "pnpm clean:modules && pnpm clean:builds && pnpm local:down && pnpm local:reset",
     "clean:builds": "find . \\( -name \"dist\" -o -name \".next\" \\) -type d -prune -exec rm -rf '{}' +",
     "clean:modules": "find . -name 'node_modules' -type d -prune -exec rm -rf '{}' +",
     "dev": "pnpm local:up && concurrently -n \"WALLET-BE,WALLET-FE,BOUTIQUE-BE,BOUTIQUE-FE\" -c blue.bold,blue,red.bold,red \"pnpm wallet:backend dev\" \"pnpm wallet:frontend dev\" \"pnpm boutique:backend dev\" \"pnpm boutique:frontend dev\"",


### PR DESCRIPTION
TL;DR - Makes the local environment setup script more robust

The local environment scripts would sometimes cause silent failures thereby confusing users in cases where the database would take a long time to start. For some reason this used to be an issue especially in Mac environments.

This PR adds better error handling and health checks to mitigate these types of problems in the future.

---

## Generated description
This pull request makes several improvements to the local development environment, focusing on more robust service readiness checks, better handling of service dependencies, and improved reliability of the Rafiki setup process. The changes ensure that dependent services only start after Postgres and Redis are fully ready, preventing startup failures and race conditions. The Rafiki setup script is enhanced to probe the admin GraphQL API for true readiness, and several configuration options are made tunable for slow environments. Additionally, minor fixes and improvements are included for asset pagination and cleaning scripts.

**Service Readiness and Dependency Handling:**

* Added `healthcheck` sections to `postgres` (`local/postgres.yaml`) and `redis` (`local/redis.yaml`) services to ensure they are actually ready before dependents start. This prevents race conditions where services attempt to connect before the database or cache is initialized. [[1]](diffhunk://#diff-5760b4277067d6c8804d18a6717e59ab55fc29e496e6088627b9a0557e173272R16-R25) [[2]](diffhunk://#diff-1e57bf6af4ae6106c2f59a338cb862178b8fd6c1295db67539767703f152c884R12-R17)
* Updated `depends_on` in `local/rafiki.yaml` so that Rafiki services wait for Postgres and Redis to be healthy before starting, using Docker Compose's `condition: service_healthy`. This avoids migration and seeding failures during container startup. [[1]](diffhunk://#diff-cd1f88ad03429ccfc250dd6282d35ea6d6fec6f2f77baff29d81ff0b4c0ebd60L43-R47) [[2]](diffhunk://#diff-cd1f88ad03429ccfc250dd6282d35ea6d6fec6f2f77baff29d81ff0b4c0ebd60L121-R133)

**Rafiki Setup Script Improvements:**

* The setup script now probes the admin GraphQL API with a signed request to ensure it is fully ready (not just `/healthz`), preventing transient authentication errors during setup. Readiness parameters are now configurable via environment variables for flexibility on slower systems. [[1]](diffhunk://#diff-01abb20f39a169abaf242453f3d1bb239990be29bb5bc2b2f5cbc914bb15c787R95-R117) [[2]](diffhunk://#diff-01abb20f39a169abaf242453f3d1bb239990be29bb5bc2b2f5cbc914bb15c787L135-R154) [[3]](diffhunk://#diff-01abb20f39a169abaf242453f3d1bb239990be29bb5bc2b2f5cbc914bb15c787R199-R231) [[4]](diffhunk://#diff-01abb20f39a169abaf242453f3d1bb239990be29bb5bc2b2f5cbc914bb15c787R587)
* Changed default endpoint URLs from `localhost` to `127.0.0.1` to avoid IPv6 resolution issues in Node 18+ that can cause connection failures with Docker's published ports.

**Other Fixes and Improvements:**

* Capped asset pagination in the setup script to 100 (from 200) to match Rafiki's enforced limit and avoid pagination errors.
* Enhanced the `clean` script in `package.json` to also bring down and reset local Docker services, ensuring a more thorough cleanup.