### PR TITLE
feat: add QR code genaration for point of sale

### DIFF
--- a/packages/wallet/frontend/src/components/WalletAddressesTable.tsx
+++ b/packages/wallet/frontend/src/components/WalletAddressesTable.tsx
@@ -21,6 +21,7 @@ import {
   replaceWalletAddressProtocol
 } from '@/utils/helpers'
 import { RegisterPOSDialog } from './dialogs/RegisterPOSDialog'
+import { GenerateQRForWADialog } from './dialogs/GenerateQRForWADialog'
 
 interface WalletAddressesTableProps {
   account: Account
@@ -123,6 +124,27 @@ const RegisterPOSforWA = () => {
   )
 }
 
+const GenerateQRForWA = () => {
+  const { walletAddress } = useContext(WalletAddressRowContext)
+  const [openDialog, closeDialog] = useDialog()
+
+  return (
+    <Link
+      aria-label="generate QR for wallet address as merchant"
+      onClick={() =>
+        openDialog(
+          <GenerateQRForWADialog
+            walletAddress={walletAddress}
+            onClose={closeDialog}
+          />
+        )
+      }
+    >
+      QR
+    </Link>
+  )
+}
+
 export const CopyWalletAddress = () => {
   const { walletAddress } = useContext(WalletAddressRowContext)
   const [isCopied, setIsCopied] = useState(false)
@@ -190,6 +212,9 @@ export const WalletAddressRow = ({
         <td>{walletAddress.isCard ? null : <DeleteWalletAddress />}</td>
         <td>
           <RegisterPOSforWA />
+        </td>
+        <td>
+          <GenerateQRForWA />
         </td>
       </tr>
     </WalletAddressRowContext.Provider>

--- a/packages/wallet/frontend/src/components/dialogs/GenerateQRForWADialog.tsx
+++ b/packages/wallet/frontend/src/components/dialogs/GenerateQRForWADialog.tsx
@@ -1,0 +1,128 @@
+import {
+  Dialog,
+  DialogPanel,
+  DialogTitle,
+  Transition,
+  TransitionChild
+} from '@headlessui/react'
+import { Fragment, useRef, useState } from 'react'
+import type { DialogProps } from '@/lib/types/dialog'
+import { IWalletAddressResponse } from '@wallet/shared'
+import { Button } from '@/ui/Button'
+import { Input } from '@/ui/forms/Input'
+import { useQRCode } from 'next-qrcode'
+
+type GenerateQRForWADialogProps = Pick<DialogProps, 'onClose'> & {
+  walletAddress: IWalletAddressResponse
+}
+
+export const GenerateQRForWADialog = ({
+  onClose,
+  walletAddress
+}: GenerateQRForWADialogProps) => {
+  const [description, setDescription] = useState('')
+  const qrContainerRef = useRef<HTMLDivElement>(null)
+  const { Image } = useQRCode()
+  const walletAddressUrl = walletAddress.url.replace('$', 'https://')
+  const qrUrl = new URL('/send', window.location.origin)
+  qrUrl.searchParams.set('merchantWA', walletAddressUrl)
+  if (description) {
+    qrUrl.searchParams.set('merchantDescription', description)
+  }
+  const qrPayload = qrUrl.toString()
+
+  const handleDownload = () => {
+    const img = qrContainerRef.current?.querySelector('img')
+    if (!img?.src) return
+
+    const link = document.createElement('a')
+    link.href = img.src
+    link.download = `Merchant-qr-code.jpeg`
+    link.click()
+  }
+
+  return (
+    <Transition show={true} as={Fragment} appear={true}>
+      <Dialog as="div" className="relative z-10" onClose={onClose}>
+        <TransitionChild
+          as={Fragment}
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-green-modal/75 dark:bg-black/75 transition-opacity" />
+        </TransitionChild>
+
+        <div className="fixed inset-0 z-10 overflow-y-auto">
+          <div className="flex min-h-full items-center justify-center p-4">
+            <TransitionChild
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0 translate-y-4"
+              enterTo="opacity-100 translate-y-0"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100 translate-y-0"
+              leaveTo="opacity-0 translate-y-4"
+            >
+              <DialogPanel className="relative w-full max-w-xl space-y-4 overflow-hidden rounded-lg bg-white dark:bg-purple p-4 shadow-xl">
+                <DialogTitle
+                  as="h3"
+                  className="text-center text-2xl font-medium"
+                >
+                  Generate QR code for a Wallet Address as a merchant
+                </DialogTitle>
+
+                <div className="flex justify-between items-center flex-col">
+                  <div>{walletAddressUrl}</div>
+                  <div className="w-full py-2">
+                    <Input
+                      label="Description"
+                      value={description}
+                      onChange={(event) => setDescription(event.target.value)}
+                    />
+                  </div>
+                  <div className="py-4" ref={qrContainerRef}>
+                    <Image
+                      text={qrPayload}
+                      options={{
+                        type: 'image/jpeg',
+                        quality: 1,
+                        errorCorrectionLevel: 'M',
+                        margin: 3,
+                        scale: 4,
+                        width: 200,
+                        color: {
+                          dark: '#000',
+                          light: '#FFFFFF'
+                        }
+                      }}
+                    />
+                  </div>
+                  <div className="flex justify-evenly w-full">
+                    <Button
+                      intent="outline"
+                      aria-label="download QR code"
+                      onClick={handleDownload}
+                    >
+                      Download
+                    </Button>
+                    <Button
+                      intent="outline"
+                      aria-label="close dialog"
+                      onClick={() => onClose()}
+                    >
+                      Done
+                    </Button>
+                  </div>
+                </div>
+              </DialogPanel>
+            </TransitionChild>
+          </div>
+        </div>
+      </Dialog>
+    </Transition>
+  )
+}


### PR DESCRIPTION
<!--
If the PR is related to an open issue(s) please provide a list of them.

Example:
    - closes (or fixes) #<issue number>
    - closes (or fixes) #<issue number>
-->

### Context

- fixes Linear issue int1-681

<!--
Short description of what has changed
-->

### Changes
The merchant needs to be able to generate a QR wwith the correct format, in order for when the user scans a QR, it takes the user to the send page with merchant details prefilled.
Added a QR link button to the Wallett Address, and a popup will appear with the choice of adding description, and downloading the QR to be printed out.