### PR TITLE
fix: local env files should not be baked in

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,4 +7,5 @@
 # Next.js loads it during `next build`, so if it reaches the build context it
 # overrides the build args baked into the published image (and dotenv-expand
 # mangles any value containing a `$`). Keep it out of image builds.
-packages/wallet/frontend/.env.local
+**/.env
+**/.env.local

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,9 @@
 **/dist
 **/Dockerfile.dev
 **/Dockerfile.prod
+
+# .env.local holds local development values and is committed to the repo.
+# Next.js loads it during `next build`, so if it reaches the build context it
+# overrides the build args baked into the published image (and dotenv-expand
+# mangles any value containing a `$`). Keep it out of image builds.
+packages/wallet/frontend/.env.local


### PR DESCRIPTION
We noticed that the local environment .env files gets baked into builds causing misconfigurations in production builds.

This PR cleans this up.