### PR TITLE
fix: switch to new form api-wallet instead of api.wallet

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,7 +145,7 @@ jobs:
             path: packages/wallet/frontend
             port: 4003
             cookie_name: testnet.cookie
-            backend_url: https://api.wallet.interledger-test.dev
+            backend_url: https://api-wallet.interledger-test.dev
             open_payments_host: $ilp.interledger-test.dev/
             auth_host: https://auth.interledger-test.dev
             gatehub_env: sandbox
@@ -163,7 +163,7 @@ jobs:
           - name: test-boutique-frontend
             identifier: 'boutique:frontend'
             path: packages/boutique/frontend
-            api_base_url: 'https://api.boutique.interledger-test.dev'
+            api_base_url: 'https://api-boutique.interledger-test.dev'
             currency: 'USD'
             theme: light
           - name: test-boutique-frontend-jopacc


### PR DESCRIPTION
Since the new environment uses cloudflare, we cannot use nested canonical domains because of a Cloudflare limitation.

Switches:
- test-wallet-frontend: backend_url → https://api-wallet.interledger-test.dev
- test-boutique-frontend: api_base_url → https://api-boutique.interledger-test.dev