### PR TITLE
feat: introduce prom client metrics

### DIFF
--- a/helm/testnet-boutique/tests/deployment.backend_test.yaml
+++ b/helm/testnet-boutique/tests/deployment.backend_test.yaml
@@ -45,6 +45,9 @@ tests:
           path: data.PORT
           value: '3004'
       - equal:
+          path: data.METRICS_PORT
+          value: '9464'
+      - equal:
           path: data.FRONTEND_URL
           value: 'https://rafiki.boutique'
       - equal:
@@ -53,3 +56,12 @@ tests:
       - equal:
           path: data.PAYMENT_POINTER
           value: 'https://ilp.rafiki.money/boutique'
+  - it: 'should expose the metrics port on the container'
+    template: deployment.backend.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports[1].name
+          value: metrics
+      - equal:
+          path: spec.template.spec.containers[0].ports[1].containerPort
+          value: 9464

--- a/helm/testnet-boutique/tests/services_test.yaml
+++ b/helm/testnet-boutique/tests/services_test.yaml
@@ -22,6 +22,15 @@ tests:
       - equal:
           path: spec.ports[0].targetPort
           value: 3004
+      - equal:
+          path: spec.ports[1].name
+          value: metrics
+      - equal:
+          path: spec.ports[1].port
+          value: 9464
+      - equal:
+          path: spec.ports[1].targetPort
+          value: 9464
   - it: 'frontend service should be created with correct name'
     template: service.frontend.yaml
     asserts:

--- a/helm/testnet-boutique/values.yaml
+++ b/helm/testnet-boutique/values.yaml
@@ -18,6 +18,7 @@ config:
 
     nodeEnv: production
     port: 3004
+    metricsPort: 9464
 
     database:
       url:
@@ -62,6 +63,9 @@ deployments:
     ports:
       - name: http
         containerPort: 3004
+        protocol: TCP
+      - name: metrics
+        containerPort: 9464
         protocol: TCP
     resources:
       requests:
@@ -123,6 +127,10 @@ services:
         targetPort: 3004
         protocol: TCP
         name: http
+      - port: 9464
+        targetPort: 9464
+        protocol: TCP
+        name: metrics
 
   frontend:
     name: frontend-service
@@ -145,6 +153,8 @@ configMaps:
         valueRef: config.backend.nodeEnv
       - key: PORT
         valueRef: config.backend.port
+      - key: METRICS_PORT
+        valueRef: config.backend.metricsPort
       - key: FRONTEND_URL
         valueRef: config.backend.frontendUrl
       - key: KEY_ID

--- a/helm/testnet-wallet/tests/deployment.backend_test.yaml
+++ b/helm/testnet-wallet/tests/deployment.backend_test.yaml
@@ -45,8 +45,20 @@ tests:
           path: data.PORT
           value: '4003'
       - equal:
+          path: data.METRICS_PORT
+          value: '9464'
+      - equal:
           path: data.COOKIE_NAME
           value: testnet.cookie
+  - it: 'should expose the metrics port on the container'
+    template: deployment.backend.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports[1].name
+          value: metrics
+      - equal:
+          path: spec.template.spec.containers[0].ports[1].containerPort
+          value: 9464
   - it: 'should handle accessSepaKey as a config'
     template: configMap.backend.yaml
     set:

--- a/helm/testnet-wallet/tests/services_test.yaml
+++ b/helm/testnet-wallet/tests/services_test.yaml
@@ -22,6 +22,15 @@ tests:
       - equal:
           path: spec.ports[0].targetPort
           value: 4003
+      - equal:
+          path: spec.ports[1].name
+          value: metrics
+      - equal:
+          path: spec.ports[1].port
+          value: 9464
+      - equal:
+          path: spec.ports[1].targetPort
+          value: 9464
   - it: 'frontend service should be created with correct name'
     template: service.frontend.yaml
     asserts:

--- a/helm/testnet-wallet/values.yaml
+++ b/helm/testnet-wallet/values.yaml
@@ -36,6 +36,7 @@ config:
     nodeEnv: production
     logLevel: info
     port: 4003
+    metricsPort: 9464
 
     cookie:
       name: 'testnet.cookie'
@@ -239,6 +240,9 @@ deployments:
       - name: http
         containerPort: 4003
         protocol: TCP
+      - name: metrics
+        containerPort: 9464
+        protocol: TCP
     resources:
       requests:
         memory: 256Mi
@@ -302,6 +306,10 @@ services:
         targetPort: 4003
         protocol: TCP
         name: http
+      - port: 9464
+        targetPort: 9464
+        protocol: TCP
+        name: metrics
 
   frontend:
     name: frontend-service
@@ -347,6 +355,8 @@ configMaps:
         valueRef: config.backend.nodeEnv
       - key: PORT
         valueRef: config.backend.port
+      - key: METRICS_PORT
+        valueRef: config.backend.metricsPort
       - key: COOKIE_NAME
         valueRef: config.backend.cookie.name
       - key: COOKIE_TTL

--- a/packages/boutique/backend/package.json
+++ b/packages/boutique/backend/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@google-cloud/logging-winston": "^6.0.1",
     "@interledger/open-payments": "^7.3.0",
+    "@prometheus-io/client": "^0.16.1",
     "@shared/backend": "workspace:*",
     "@boutique/shared": "workspace:*",
     "awilix": "^12.0.5",

--- a/packages/boutique/backend/src/app.ts
+++ b/packages/boutique/backend/src/app.ts
@@ -5,11 +5,16 @@ import helmet from 'helmet'
 import type { Server } from 'http'
 import type { Cradle } from './container'
 import { Model } from 'objection'
-import { initErrorHandler } from '@shared/backend'
+import {
+  initErrorHandler,
+  createHttpMetrics,
+  startMetricsServer
+} from '@shared/backend'
 import path from 'path'
 
 export class App {
   private server!: Server
+  private metricsServer!: Server
 
   constructor(private container: AwilixContainer<Cradle>) {}
 
@@ -18,6 +23,7 @@ export class App {
     const env = this.container.resolve('env')
     const logger = this.container.resolve('logger')
     const knex = this.container.resolve('knex')
+    const metricsRegistry = this.container.resolve('metricsRegistry')
 
     await knex.migrate.latest({
       directory: __dirname + '/../migrations'
@@ -27,10 +33,14 @@ export class App {
 
     this.server = express.listen(env.PORT)
     logger.info(`Boutique server started on port ${env.PORT}`)
+
+    this.metricsServer = startMetricsServer(metricsRegistry, env.METRICS_PORT)
+    logger.info(`Metrics server started on port ${env.METRICS_PORT}`)
   }
 
   public stop = async (): Promise<void> => {
     this.server.close()
+    this.metricsServer?.close()
   }
 
   public getPort(): number {
@@ -47,9 +57,13 @@ export class App {
 
     const env = this.container.resolve('env')
     const logger = this.container.resolve('logger')
+    const metricsRegistry = this.container.resolve('metricsRegistry')
     const productController = this.container.resolve('productController')
     const orderController = this.container.resolve('orderController')
     const frontendOrigin = new URL(env.FRONTEND_URL).origin
+
+    const { httpMetricsMiddleware } = createHttpMetrics(metricsRegistry)
+    app.use(httpMetricsMiddleware)
 
     app.use(
       cors({
@@ -63,6 +77,7 @@ export class App {
         crossOriginResourcePolicy: false
       })
     )
+
     app.use(express.json())
     app.use(express.urlencoded({ extended: true, limit: '25mb' }))
     app.use(

--- a/packages/boutique/backend/src/config/env.ts
+++ b/packages/boutique/backend/src/config/env.ts
@@ -28,7 +28,12 @@ const base64String = requiredString.refine(
 
 const envSchema = z.object({
   PORT: z.coerce.number(),
-  METRICS_PORT: z.coerce.number().default(9464),
+  // Different default than wallet-backend's (9464): the root `pnpm dev` runs
+  // both backends concurrently on one machine, and identical defaults would
+  // collide (EADDRINUSE) unless METRICS_PORT is manually overridden. Each
+  // Helm chart still sets this explicitly per pod, so the two defaults never
+  // need to match in deployed environments.
+  METRICS_PORT: z.coerce.number().default(9465),
   NODE_ENV: z.string().min(1),
   FRONTEND_URL: z.string().url(),
   DATABASE_URL: z.string().url(),

--- a/packages/boutique/backend/src/config/env.ts
+++ b/packages/boutique/backend/src/config/env.ts
@@ -28,6 +28,7 @@ const base64String = requiredString.refine(
 
 const envSchema = z.object({
   PORT: z.coerce.number(),
+  METRICS_PORT: z.coerce.number().default(9464),
   NODE_ENV: z.string().min(1),
   FRONTEND_URL: z.string().url(),
   DATABASE_URL: z.string().url(),

--- a/packages/boutique/backend/src/container.ts
+++ b/packages/boutique/backend/src/container.ts
@@ -24,12 +24,18 @@ import { IPaymentService, PaymentService } from './payment/service'
 import { type OneClickCache, OneClickCacheData } from './cache/one-click'
 import { generateLogger } from '@/config/logger'
 import { generateKnex } from '@/config/knex'
-import { asClassSingletonWithLogger, InMemoryCache } from '@shared/backend'
+import {
+  asClassSingletonWithLogger,
+  InMemoryCache,
+  createMetricsRegistry,
+  type Registry
+} from '@shared/backend'
 
 export interface Cradle {
   env: Env
   logger: Logger
   knex: Knex
+  metricsRegistry: Registry
   opClient: AuthenticatedClient
   oneClickCache: OneClickCache
   tokenCache: TokenCache
@@ -61,6 +67,7 @@ export async function createContainer(
   container.register({
     env: asValue(env),
     logger: asValue(logger),
+    metricsRegistry: asFunction(createMetricsRegistry).singleton(),
     opClient: asValue(client),
     openPayments: asClassSingletonWithLogger(OpenPayments, logger),
     tokenCache: asClassSingletonWithLogger(TokenCache, logger),

--- a/packages/boutique/backend/tests/app.ts
+++ b/packages/boutique/backend/tests/app.ts
@@ -25,6 +25,7 @@ export const createApp = async (
   const knex = container.resolve('knex')
 
   env.PORT = 0
+  env.METRICS_PORT = 0
   const app = new App(container)
   await start(app)
 

--- a/packages/shared/backend/jest.config.json
+++ b/packages/shared/backend/jest.config.json
@@ -1,0 +1,9 @@
+{
+  "preset": "ts-jest",
+  "clearMocks": true,
+  "testEnvironment": "node",
+  "modulePathIgnorePatterns": ["<rootDir>/dist/"],
+  "moduleNameMapper": {
+    "@/(.*)": "<rootDir>/src/$1"
+  }
+}

--- a/packages/shared/backend/package.json
+++ b/packages/shared/backend/package.json
@@ -9,18 +9,23 @@
   ],
   "scripts": {
     "build": "tsc --build tsconfig.build.json && tsc-alias -p tsconfig.build.json",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest --passWithNoTests --maxWorkers=75%"
   },
   "author": "",
   "license": "ISC",
   "devDependencies": {
     "@types/express": "^4.17.23",
+    "@types/jest": "^29.5.14",
     "@types/node": "^24.13.1",
     "ioredis": "^5.8.0",
+    "jest": "^29.7.0",
+    "node-mocks-http": "^1.17.2",
+    "ts-jest": "^29.4.4",
     "tsc-alias": "^1.8.16",
     "typescript": "^5.9.3"
   },
   "dependencies": {
+    "@prometheus-io/client": "^0.16.1",
     "awilix": "^12.0.5",
     "axios": "^1.12.2",
     "express": "^4.21.2",

--- a/packages/shared/backend/src/middleware/index.ts
+++ b/packages/shared/backend/src/middleware/index.ts
@@ -1,1 +1,2 @@
 export * from './errorHandler'
+export * from './metrics'

--- a/packages/shared/backend/src/middleware/metrics.ts
+++ b/packages/shared/backend/src/middleware/metrics.ts
@@ -1,0 +1,80 @@
+import {
+  Registry,
+  Histogram,
+  Gauge,
+  collectDefaultMetrics
+} from '@prometheus-io/client'
+import type { Request, Response, NextFunction } from 'express'
+import http, { type Server } from 'http'
+
+export function createMetricsRegistry(): Registry {
+  const register = new Registry()
+  collectDefaultMetrics({ register, eventLoopMonitoringPrecision: 5 })
+  return register
+}
+
+export function createHttpMetrics(register: Registry) {
+  const httpRequestDuration = new Histogram({
+    name: 'http_request_duration_seconds',
+    help: 'Duration of HTTP requests in seconds',
+    labelNames: ['method', 'route', 'status_code'] as const,
+    buckets: [0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30],
+    registers: [register]
+  })
+
+  const httpRequestsInFlight = new Gauge({
+    name: 'http_requests_in_flight',
+    help: 'Number of in-flight HTTP requests',
+    labelNames: ['method'] as const,
+    registers: [register]
+  })
+
+  const httpMetricsMiddleware = (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ) => {
+    const end = httpRequestDuration.startTimer()
+    httpRequestsInFlight.inc({ method: req.method })
+    res.on('finish', () => {
+      httpRequestsInFlight.dec({ method: req.method })
+      // req.route is unset for router.use('*', ...) catch-alls (used for 404s
+      // in both apps), so without this fallback every unmatched/scanned path
+      // would become its own label series (unbounded cardinality).
+      const route = req.route?.path
+        ? `${req.baseUrl}${req.route.path}`
+        : 'unmatched'
+      end({ method: req.method, route, status_code: String(res.statusCode) })
+    })
+    next()
+  }
+
+  return { httpMetricsMiddleware, httpRequestDuration, httpRequestsInFlight }
+}
+
+// Serves /metrics on its own port, separate from the app's main HTTP port,
+// so Prometheus scraping never has to be threaded through cors/helmet/auth
+// middleware ordering on the app router.
+export function startMetricsServer(register: Registry, port: number): Server {
+  const server = http.createServer((req, res) => {
+    if (req.url !== '/metrics') {
+      res.statusCode = 404
+      res.end()
+      return
+    }
+    register
+      .metrics()
+      .then((body) => {
+        res.setHeader('Content-Type', register.contentType)
+        res.end(body)
+      })
+      .catch((e) => {
+        res.statusCode = 500
+        res.end(e instanceof Error ? e.message : 'Internal Server Error')
+      })
+  })
+  server.listen(port)
+  return server
+}
+
+export type { Registry } from '@prometheus-io/client'

--- a/packages/shared/backend/src/middleware/metrics.ts
+++ b/packages/shared/backend/src/middleware/metrics.ts
@@ -36,7 +36,14 @@ export function createHttpMetrics(register: Registry) {
   ) => {
     const end = httpRequestDuration.startTimer()
     httpRequestsInFlight.inc({ method: req.method })
-    res.on('finish', () => {
+
+    // 'finish' doesn't fire if the client disconnects early (aborted request,
+    // timeout) — 'close' covers that case, but also fires after a normal
+    // 'finish'. Guard so the gauge/histogram are finalized exactly once.
+    let finalized = false
+    const finalize = () => {
+      if (finalized) return
+      finalized = true
       httpRequestsInFlight.dec({ method: req.method })
       // req.route is unset for router.use('*', ...) catch-alls (used for 404s
       // in both apps), so without this fallback every unmatched/scanned path
@@ -45,7 +52,9 @@ export function createHttpMetrics(register: Registry) {
         ? `${req.baseUrl}${req.route.path}`
         : 'unmatched'
       end({ method: req.method, route, status_code: String(res.statusCode) })
-    })
+    }
+    res.once('finish', finalize)
+    res.once('close', finalize)
     next()
   }
 

--- a/packages/shared/backend/tests/middleware/metrics.test.ts
+++ b/packages/shared/backend/tests/middleware/metrics.test.ts
@@ -13,6 +13,24 @@ import {
 const createMockResponse = () =>
   createResponse<Response>({ eventEmitter: EventEmitter })
 
+// server.address() is null until the socket has actually bound (.listen()
+// only schedules that async) and can also be a string (unix socket) rather
+// than an AddressInfo — wait for 'listening' and check the shape before
+// reading .port, instead of assuming it's already there.
+function getListeningPort(server: http.Server): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject)
+    server.once('listening', () => {
+      const address = server.address()
+      if (address === null || typeof address === 'string') {
+        reject(new Error('Expected server to be listening on a port'))
+        return
+      }
+      resolve(address.port)
+    })
+  })
+}
+
 function get(
   port: number,
   path: string
@@ -33,7 +51,7 @@ describe('metrics middleware', (): void => {
     const register = createMetricsRegistry()
     // port 0 lets the OS assign a free ephemeral port
     const server = startMetricsServer(register, 0)
-    const port = (server.address() as { port: number }).port
+    const port = await getListeningPort(server)
 
     try {
       const { status, body } = await get(port, '/metrics')
@@ -47,7 +65,7 @@ describe('metrics middleware', (): void => {
   it('startMetricsServer 404s on any other path', async (): Promise<void> => {
     const register = createMetricsRegistry()
     const server = startMetricsServer(register, 0)
-    const port = (server.address() as { port: number }).port
+    const port = await getListeningPort(server)
 
     try {
       const { status } = await get(port, '/does-not-exist')

--- a/packages/shared/backend/tests/middleware/metrics.test.ts
+++ b/packages/shared/backend/tests/middleware/metrics.test.ts
@@ -1,0 +1,111 @@
+import { Request, Response } from 'express'
+import { createRequest, createResponse } from 'node-mocks-http'
+import { EventEmitter } from 'events'
+import http from 'http'
+import {
+  createMetricsRegistry,
+  createHttpMetrics,
+  startMetricsServer
+} from '@/middleware/metrics'
+
+// httpMetricsMiddleware relies on the real 'finish' event; node-mocks-http's
+// default response stubs out EventEmitter, so it must be opted back in.
+const createMockResponse = () => createResponse<Response>({ eventEmitter: EventEmitter })
+
+function get(port: number, path: string): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    http
+      .get(`http://localhost:${port}${path}`, (res) => {
+        let body = ''
+        res.on('data', (chunk) => (body += chunk))
+        res.on('end', () =>
+          resolve({ status: res.statusCode ?? 0, body })
+        )
+      })
+      .on('error', reject)
+  })
+}
+
+describe('metrics middleware', (): void => {
+  it('startMetricsServer exposes Prometheus exposition format on /metrics', async (): Promise<void> => {
+    const register = createMetricsRegistry()
+    // port 0 lets the OS assign a free ephemeral port
+    const server = startMetricsServer(register, 0)
+    const port = (server.address() as { port: number }).port
+
+    try {
+      const { status, body } = await get(port, '/metrics')
+      expect(status).toBe(200)
+      expect(body).toContain('process_cpu_user_seconds_total')
+    } finally {
+      server.close()
+    }
+  })
+
+  it('startMetricsServer 404s on any other path', async (): Promise<void> => {
+    const register = createMetricsRegistry()
+    const server = startMetricsServer(register, 0)
+    const port = (server.address() as { port: number }).port
+
+    try {
+      const { status } = await get(port, '/does-not-exist')
+      expect(status).toBe(404)
+    } finally {
+      server.close()
+    }
+  })
+
+  it('records a request with a route label when req.route is set', async (): Promise<void> => {
+    const register = createMetricsRegistry()
+    const { httpMetricsMiddleware, httpRequestDuration } =
+      createHttpMetrics(register)
+    const req = createRequest<Request>({
+      method: 'GET',
+      route: { path: '/accounts/:id' },
+      baseUrl: ''
+    })
+    const res = createMockResponse()
+    const next = jest.fn()
+
+    httpMetricsMiddleware(req, res, next)
+    res.statusCode = 200
+    res.emit('finish')
+
+    expect(next).toHaveBeenCalled()
+    const metric = await httpRequestDuration.get()
+    const sample = metric.values.find((v) => v.metricName?.endsWith('_count'))
+    expect(sample?.labels).toMatchObject({
+      method: 'GET',
+      route: '/accounts/:id',
+      status_code: '200'
+    })
+  })
+
+  it('falls back to an "unmatched" route label when req.route is unset', async (): Promise<void> => {
+    const register = createMetricsRegistry()
+    const { httpMetricsMiddleware, httpRequestDuration } =
+      createHttpMetrics(register)
+    const req = createRequest<Request>({ method: 'GET' })
+    const res = createMockResponse()
+
+    httpMetricsMiddleware(req, res, jest.fn())
+    res.statusCode = 404
+    res.emit('finish')
+
+    const secondReq = createRequest<Request>({ method: 'GET' })
+    const secondRes = createMockResponse()
+    httpMetricsMiddleware(secondReq, secondRes, jest.fn())
+    secondRes.statusCode = 404
+    secondRes.emit('finish')
+
+    const metric = await httpRequestDuration.get()
+    const unmatchedSamples = metric.values.filter(
+      (v) =>
+        v.metricName?.endsWith('_count') &&
+        (v.labels as Record<string, string>).route === 'unmatched'
+    )
+    // Both bogus requests must collapse into a single label series, not two.
+    expect(unmatchedSamples).toHaveLength(1)
+    expect(unmatchedSamples[0].value).toBe(2)
+  })
+})

--- a/packages/shared/backend/tests/middleware/metrics.test.ts
+++ b/packages/shared/backend/tests/middleware/metrics.test.ts
@@ -10,17 +10,19 @@ import {
 
 // httpMetricsMiddleware relies on the real 'finish' event; node-mocks-http's
 // default response stubs out EventEmitter, so it must be opted back in.
-const createMockResponse = () => createResponse<Response>({ eventEmitter: EventEmitter })
+const createMockResponse = () =>
+  createResponse<Response>({ eventEmitter: EventEmitter })
 
-function get(port: number, path: string): Promise<{ status: number; body: string }> {
+function get(
+  port: number,
+  path: string
+): Promise<{ status: number; body: string }> {
   return new Promise((resolve, reject) => {
     http
       .get(`http://localhost:${port}${path}`, (res) => {
         let body = ''
         res.on('data', (chunk) => (body += chunk))
-        res.on('end', () =>
-          resolve({ status: res.statusCode ?? 0, body })
-        )
+        res.on('end', () => resolve({ status: res.statusCode ?? 0, body }))
       })
       .on('error', reject)
   })

--- a/packages/wallet/backend/package.json
+++ b/packages/wallet/backend/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@google-cloud/logging-winston": "^6.0.1",
     "@interledger/tlv-kit": "^1.1.0",
+    "@prometheus-io/client": "^0.16.1",
     "@sendgrid/mail": "^8.1.6",
     "@shared/backend": "workspace:*",
     "@wallet/shared": "workspace:*",

--- a/packages/wallet/backend/src/app.ts
+++ b/packages/wallet/backend/src/app.ts
@@ -48,7 +48,13 @@ import { SocketService } from './socket/service'
 import { GrantService } from '@/grant/service'
 import { AwilixContainer } from 'awilix'
 import { Cradle } from '@/createContainer'
-import { Forbidden, initErrorHandler, RedisClient } from '@shared/backend'
+import {
+  Forbidden,
+  initErrorHandler,
+  RedisClient,
+  createHttpMetrics,
+  startMetricsServer
+} from '@shared/backend'
 import { GateHubController } from '@/gatehub/controller'
 import { GateHubClient } from '@/gatehub/client'
 import { GateHubService } from '@/gatehub/service'
@@ -100,6 +106,7 @@ export interface Bindings {
 
 export class App {
   private server!: Server
+  private metricsServer!: Server
 
   constructor(private container: AwilixContainer<Cradle>) {}
 
@@ -109,6 +116,7 @@ export class App {
     const logger = this.container.resolve('logger')
     const knex = this.container.resolve('knex')
     const socketService = this.container.resolve('socketService')
+    const metricsRegistry = this.container.resolve('metricsRegistry')
 
     await knex.migrate.latest({
       directory: __dirname + '/../migrations'
@@ -117,6 +125,9 @@ export class App {
 
     this.server = express.listen(env.PORT)
     logger.info(`Server started on port ${env.PORT}`)
+
+    this.metricsServer = startMetricsServer(metricsRegistry, env.METRICS_PORT)
+    logger.info(`Metrics server started on port ${env.METRICS_PORT}`)
 
     // Log the browser-facing auth configuration on every boot. These values
     // fail silently when wrong — a bad cookie domain or a missing CORS origin
@@ -137,6 +148,7 @@ export class App {
 
   public stop = async (): Promise<void> => {
     this.server.close()
+    this.metricsServer?.close()
   }
 
   public getPort(): number {
@@ -154,6 +166,7 @@ export class App {
 
     const env = this.container.resolve('env')
     const logger = this.container.resolve('logger')
+    const metricsRegistry = this.container.resolve('metricsRegistry')
     const authController = this.container.resolve('authController')
     const userController = this.container.resolve('userController')
     const walletAddressController = this.container.resolve(
@@ -186,6 +199,9 @@ export class App {
       'interledgerCardController'
     )
     const terminalController = this.container.resolve('terminalController')
+
+    const { httpMetricsMiddleware } = createHttpMetrics(metricsRegistry)
+    app.use(httpMetricsMiddleware)
 
     app.use(
       cors({

--- a/packages/wallet/backend/src/config/env.ts
+++ b/packages/wallet/backend/src/config/env.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 
 const envSchema = z.object({
   PORT: z.coerce.number().default(3000),
+  METRICS_PORT: z.coerce.number().default(9464),
   NODE_ENV: z.string().default('development'),
   DATABASE_URL: z
     .string()

--- a/packages/wallet/backend/src/createContainer.ts
+++ b/packages/wallet/backend/src/createContainer.ts
@@ -44,7 +44,12 @@ import {
 import { WalletAddressKeyController } from '@/walletAddressKeys/controller'
 import { WalletAddressKeyService } from '@/walletAddressKeys/service'
 import { generateKnex } from '@/config/knex'
-import { asClassSingletonWithLogger, RedisClient } from '@shared/backend'
+import {
+  asClassSingletonWithLogger,
+  RedisClient,
+  createMetricsRegistry,
+  type Registry
+} from '@shared/backend'
 import { generateLogger } from '@/config/logger'
 import { GraphQLClient } from 'graphql-request'
 import { KratosService } from './rafiki/kratos.service'
@@ -59,11 +64,11 @@ import { InterledgerCardController } from '@/interledgerCard/controller'
 import { InterledgerCardService } from '@/interledgerCard/service'
 import { TerminalController } from '@/terminal/controller'
 import { TerminalService } from '@/terminal/service'
-
 export interface Cradle {
   env: Env
   logger: Logger
   knex: Knex
+  metricsRegistry: Registry
   sessionService: SessionService
   emailService: EmailService
   userService: UserService
@@ -121,6 +126,7 @@ export async function createContainer(
   container.register({
     env: asValue(env),
     logger: asValue(logger),
+    metricsRegistry: asFunction(createMetricsRegistry).singleton(),
     knex: asFunction(generateKnex).singleton(),
     sessionService: asClass(SessionService).singleton(),
     emailService: asClassSingletonWithLogger(EmailService, logger),

--- a/packages/wallet/backend/tests/app.ts
+++ b/packages/wallet/backend/tests/app.ts
@@ -17,6 +17,7 @@ export const createApp = async (
   const knex = await container.resolve('knex')
 
   env.PORT = 0
+  env.METRICS_PORT = 0
   const app = new App(container)
   await start(app)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       '@interledger/open-payments':
         specifier: ^7.3.0
         version: 7.3.0
+      '@prometheus-io/client':
+        specifier: ^0.16.1
+        version: 0.16.1
       '@shared/backend':
         specifier: workspace:*
         version: link:../../shared/backend
@@ -266,6 +269,9 @@ importers:
 
   packages/shared/backend:
     dependencies:
+      '@prometheus-io/client':
+        specifier: ^0.16.1
+        version: 0.16.1
       awilix:
         specifier: ^12.0.5
         version: 12.0.5
@@ -288,12 +294,24 @@ importers:
       '@types/express':
         specifier: ^4.17.23
         version: 4.17.23
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
       '@types/node':
         specifier: ^24.13.1
         version: 24.13.1
       ioredis:
         specifier: ^5.8.0
         version: 5.8.0
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.13.1)(babel-plugin-macros@3.1.0)
+      node-mocks-http:
+        specifier: ^1.17.2
+        version: 1.17.2(@types/express@4.17.23)(@types/node@24.13.1)
+      ts-jest:
+        specifier: ^29.4.4
+        version: 29.4.4(@babel/core@7.25.2)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.2))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.13.1)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
       tsc-alias:
         specifier: ^1.8.16
         version: 1.8.16
@@ -309,6 +327,9 @@ importers:
       '@interledger/tlv-kit':
         specifier: ^1.1.0
         version: 1.1.0
+      '@prometheus-io/client':
+        specifier: ^0.16.1
+        version: 0.16.1
       '@sendgrid/mail':
         specifier: ^8.1.6
         version: 8.1.6
@@ -1912,6 +1933,10 @@ packages:
   '@polka/url@1.0.0-next.25':
     resolution: {integrity: sha512-j7P6Rgr3mmtdkeDGTe0E/aYyWEWVtc5yFXtHCRHs28/jptDEWfaVOc5T7cblqy1XKPPfCxJc/8DwQ5YgLOZOVQ==}
 
+  '@prometheus-io/client@0.16.1':
+    resolution: {integrity: sha512-XkFPsGFGoSs/UMg/vh0QLDpanl/tsrOV5PLHdpGe8Ho+ir/Llhytr15j6y8ZwLrpIGzK9gTVVpIalA6C4UjUZw==}
+    engines: {node: ^22 || ^24 || >=26}
+
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
 
@@ -3150,6 +3175,9 @@ packages:
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
+
+  bintrees@1.0.2:
+    resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
@@ -6566,6 +6594,9 @@ packages:
     resolution: {integrity: sha512-51LAVKUSZSVfI05vjPESNc5vwqqZpbXCsU+/+wxlOrUjk2SnFTt97v9ZgQrD4YmxYW1Px6w2KjaDitCfkvgxMQ==}
     engines: {node: '>=8.0.0'}
 
+  tdigest@0.1.3:
+    resolution: {integrity: sha512-zbRt+lT+/H4fRItHshczHErVCQnitJk8MfMT24MqFJf3YL7SJJPqGIGeuOdvxXxM/AHFzKBl7WoyaYwqO9s3Kw==}
+
   teeny-request@9.0.0:
     resolution: {integrity: sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==}
     engines: {node: '>=14'}
@@ -8810,6 +8841,11 @@ snapshots:
 
   '@polka/url@1.0.0-next.25': {}
 
+  '@prometheus-io/client@0.16.1':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      tdigest: 0.1.3
+
   '@protobufjs/aspromise@1.1.2': {}
 
   '@protobufjs/base64@1.1.2': {}
@@ -10132,6 +10168,8 @@ snapshots:
   bignumber.js@9.1.2: {}
 
   binary-extensions@2.3.0: {}
+
+  bintrees@1.0.2: {}
 
   bl@4.1.0:
     dependencies:
@@ -14135,6 +14173,10 @@ snapshots:
       streamx: 2.18.0
 
   tarn@3.0.2: {}
+
+  tdigest@0.1.3:
+    dependencies:
+      bintrees: 1.0.2
 
   teeny-request@9.0.0:
     dependencies:


### PR DESCRIPTION
### Context
We have a problem where are really struggle to understand the reason of performance bottlenecks. This is especially true whenever the wallet appears unexpectedly slow.

This pull request adds Prometheus-compatible HTTP metrics to both the Boutique and Wallet backend services, enabling improved observability and monitoring. It introduces a new metrics server running on a dedicated port, exposes metrics via a `/metrics` endpoint, and integrates middleware to collect HTTP request metrics. The changes are thoroughly tested and configurable via Helm charts and environment variables.
